### PR TITLE
Need "no" locale in addition to "nb" and "nn"

### DIFF
--- a/res/values-nb/README.txt
+++ b/res/values-nb/README.txt
@@ -1,0 +1,1 @@
+nb and no locale are the same, please synchronize any changes between the two.

--- a/res/values-no/README.txt
+++ b/res/values-no/README.txt
@@ -1,0 +1,1 @@
+nb and no locale are the same, please synchronize any changes between the two.

--- a/res/values-no/strings-preferences.xml
+++ b/res/values-no/strings-preferences.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+	<!-- Preferences -->
+	<string name="prefs">Innstillinger</string>
+
+	<string name="prefs_gps">GPS</string>
+
+	<string name="prefs_gps_os_settings">GPS-innstillinger</string>
+	<string name="prefs_gps_os_settings_summary">Gå til systeminnstillinger for GPS</string>
+
+	<string name="prefs_check_gps_startup">Sjekk GPS ved programstart</string>
+	<string name="prefs_check_gps_startup_summary">Sjekk om GPS er slått av ved programstart, og gi høve til å slå den på</string>
+
+	<string name="prefs_gps_ignore_clock">Ignorer GPS-tid</string>
+	<string name="prefs_gps_ignore_clock_summary">Ignorer GPS-tid og bruk Android-klokka for tidsstempel</string>
+
+	<string name="prefs_gps_logging_interval">Logg-intervall</string>
+	<string name="prefs_gps_logging_interval_summary">Bruk 0 for kortest mulig mellomrom mellom sporpunkt (påvirker batteriet)</string>
+	<string name="prefs_gps_logging_interval_seconds">sekund</string>
+
+	<string name="prefs_ui">Brukergrensesnitt</string>
+	
+	<string name="prefs_ui_buttons_layout">Knappelayout</string>
+	<string name="prefs_ui_buttons_layout_summary">Velg en annen knappelayout (se dokumentasjon)</string>
+	<string name="prefs_ui_buttons_layout_defaut">Standard</string>
+	<string name="prefs_ui_orientation">Retning</string>
+	<string name="prefs_ui_orientation_summary">Foretrukket retning for knappeskjermen</string>
+	<string-array name="prefs_ui_orientation_options_keys">
+		<item>Automatisk</item>
+		<item>Portrett</item>
+		<item>Landskap</item>
+	</string-array>
+	<!-- DO NOT TRANSLATE THIS (BEGIN) -->
+	<string-array name="prefs_ui_orientation_options_values">
+		<item>none</item>
+		<item>portrait</item>
+		<item>landscape</item>
+	</string-array>
+	<!-- DO NOT TRANSLATE THIS (END) -->
+	
+
+	<string name="prefs_voicerec_duration">Lengde på stemmeopptak</string>
+	<string name="prefs_voicerec_duration_seconds">sekund</string>
+	<!-- DO NOT TRANSLATE THIS (BEGIN) -->
+	<string-array name="prefs_voicerec_durations">
+		<item>2</item>
+		<item>3</item>
+		<item>4</item>
+		<item>5</item>
+		<item>10</item>
+		<item>20</item>
+		<item>30</item>
+	</string-array>
+	<!-- DO NOT TRANSLATE THIS (END) -->
+	
+	<string name="prefs_theme">Drakt for knappeskjermen</string>
+	<string name="prefs_theme_summary">Programmet må startes om for å aktivere endring</string>
+	<string-array name="prefs_theme_keys">
+		<item>OS-standard</item>
+		<item>OS-standard (mørk)</item>
+		<item>OS-standard (lys)</item>
+		<item>Høy kontrast</item>
+	</string-array>
+	<!-- DO NOT TRANSLATE THIS (BEGIN) -->
+	<string-array name="prefs_theme_values">
+		<item>android:style/Theme</item>
+		<item>android:style/Theme.Black</item>
+		<item>android:style/Theme.Light</item>
+		<item>me.guillaumin.android.osmtracker:style/HighContrast</item>
+	</string-array>
+	<!-- DO NOT TRANSLATE THIS (END) -->
+
+	<string name="prefs_display_always_on">Skjerm alltid på</string>
+	<string name="prefs_display_always_on_summary">Skjermen er alltid på under sporing. Slå av for å spare batteri</string>
+
+	<string name="prefs_displaytrack_osm">OSM-bakgrunn</string>
+	<string name="prefs_displaytrack_osm_summary">Vis OpenStreetMap under sporet. Bruker datatilkobling</string>
+
+	<string name="prefs_output">GPX-filvalg</string>
+	<string name="prefs_storage_dir">Mappe på ekstern lagringsenhet (SD)</string>
+	<string name="prefs_storage_dir_hint">Blir aktivert for neste spor</string>
+	<string name="prefs_output_one_dir_per_track">En mappe per spor</string>
+	<string name="prefs_output_one_dir_per_track_summary">Lagre hvert spor og tilhørende filer til deres egne mapper</string>
+	<string name="prefs_output_filename">Filnavn på navngitte spor</string>
+	<string name="prefs_output_filename_summary">Mønster på filnavnet dersom sporet har fått navn</string>
+	<string-array name="prefs_output_filename_keys">
+		<item>Spornavn</item>
+		<item>Spornavn, startdato og -tid</item>
+		<item>Startdato og -tid</item>
+	</string-array>
+	<!-- DO NOT TRANSLATE THIS (BEGIN) -->
+	<string-array name="prefs_output_filename_values">
+		<item>name</item>
+		<item>name_date</item>
+		<item>date</item>
+	</string-array>
+	<!-- DO NOT TRANSLATE THIS (END) -->
+	
+	<string name="prefs_output_accuracy">Presisjon i GPX-fil</string>
+	<string name="prefs_output_accuracy_summary">Legg til presisjonsinformasjon i GPX-fila, sammen med sporpunktnavn eller i sporpunktkommentar</string>
+	<string-array name="prefs_output_accuracy_keys">
+		<item>Intet</item>
+		<item>Sammen med sporpunktnavn</item>
+		<item>I sporpunktkommentar</item>
+	</string-array>
+	<!-- DO NOT TRANSLATE THIS (BEGIN) -->
+	<string-array name="prefs_output_accuracy_values">
+		<item>none</item>
+		<item>wpt_name</item>
+		<item>wpt_cmt</item>
+	</string-array>
+	<!-- DO NOT TRANSLATE THIS (END) -->
+	
+	<string name="prefs_output_gpx_hdop_approximation">Bruk HDOP-estimat</string>
+	<string name="prefs_output_gpx_hdop_approximation_summary">Estimer HDOP frå presisjonsverdi</string>
+
+	<string name="prefs_sound_enabled">Slå på lyd</string>
+	<string name="prefs_sound_enabled_summary">Spill av en lyd når stemmeopptak begynner og slutter</string>
+
+</resources>

--- a/res/values-no/strings.xml
+++ b/res/values-no/strings.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<!-- Generic strings -->
+	<string name="app_name">OSMTracker for Android™</string>
+	<string name="app_short_name">OSMTracker</string>
+	<string name="app_description">OSMTracker lar deg spore reisene dine, merke av viktige punkt ved hjelp av et notat, foto eller stemmeopptak. Sporet kan du så eksportere til GPX-formatet som så kan brukes med ulike OpenStreetMap-verktøy som til dømes JOSM. OSMTracker er inspirert av OSMTracker for Windows Mobile.</string>
+
+	<!-- TrackLogger -->
+	<string name="tracklogger">Sporlogger</string>
+	<string name="tracklogger_waiting_gps">Venter på posisjon fra GPS for å aktivere knappene&#8230;</string>
+	<string name="tracklogger_voicerec_title">Stemmeopptak</string>
+	<string name="tracklogger_voicerec_text">Ta opp et {0} sekunds lydklipp.</string>
+	<string name="tracklogger_voicerec_stop">Stopp</string>
+	<string name="tracklogger_btnBack">Tilbake</string>
+	<string name="tracklogger_tracked">Spora: </string>
+	<string name="tracklogger_gps_disabled">GPS er avslått</string>
+	<string name="tracklogger_gps_disabled_hint">GPS er avslått. Vil du slå den på?</string>
+
+	<!-- Waypoint List -->
+	<string name="wplist">Rutepunktliste</string>
+	<string name="wplist_latitude">Breddegrad: </string>
+	<string name="wplist_longitude">Lengdegrad: </string>
+	<string name="wplist_elevation">Moh: </string>
+	<string name="wplist_accuracy">Presisjon: </string>
+	
+	<!-- Track Manager -->
+	<string name="trackmgr">Sporbehandler</string>
+	<string name="trackmgr_tracklist">Sporliste:</string>
+	<string name="trackmgr_waypoints_count">Rutepunkt: </string>
+	<string name="trackmgr_trackpoints_count">Sporpunkt: </string>
+	<string name="trackmgr_empty">Du har ingen spor.</string>
+	<string name="trackmgr_newtrack_hint">Trykk på <b>Meny</b> og så <b>Nytt spor</b> for å spore.</string>
+	<string name="trackmgr_newtrack_error">Kan ikke lage spor: {0}</string>
+	<string name="trackmgr_continuetrack_hint">Du tar nå opp <b>spor nr. {0}</b>\nVelg det i lista for å holde fram med sporinga</string>
+	<string name="trackmgr_contextmenu_stop">Stopp sporing</string>
+	<string name="trackmgr_contextmenu_resume">Fortsett sporing</string>
+	<string name="trackmgr_contextmenu_delete">Slett</string>
+	<string name="trackmgr_contextmenu_export">Eksporter som GPX</string>
+	<string name="trackmgr_contextmenu_display">Vis</string>
+	<string name="trackmgr_contextmenu_details">Detaljer</string>
+	<string name="trackmgr_contextmenu_title">Spor nr. {0}</string>
+	<string name="trackmgr_delete_confirm">Spor nr. {0} vil bli sletta</string>
+	<string name="trackmgr_deleteall_confirm">Alle spor vil bli sletta. Er du sikker?</string>
+	<string name="trackmgr_exporting">Eksporterer spor nr. {0}&#8230;</string>
+	<string name="trackmgr_export_error">Kan ikke eksportere spor nr: {0}</string>
+
+	<!-- Track Detail -->
+	<string name="trackdetail">Spordetaljer</string>
+	<string name="trackdetail_startdate">Starttid:</string>
+	<string name="trackdetail_enddate">Sluttid:</string>
+	<string name="trackdetail_startloc">Begynnelse:</string>
+	<string name="trackdetail_endloc">Slutt:</string>
+	<string name="trackdetail_exportdate">Eksportert:</string>
+	<string name="trackdetail_btn_export">Eksportert som GPX</string>
+	<string name="trackdetail_export_notyet">(Ikke eksportert ennå)</string>
+	<string name="trackdetail_export_display">Vis</string>
+
+	<!-- GPS Status & record bar -->
+	<string name="gpsstatus_record_voicerec">Stemmeopptak</string>
+	<string name="gpsstatus_record_stillimage">Ta bilde</string>
+	<string name="gpsstatus_record_textnote">Tekstnotat</string>
+
+	<!-- Menu -->
+	<string name="menu_settings">Innstillinger</string>
+	<string name="menu_waypointlist">Rutepunkt</string>
+	<string name="menu_about">Om</string>
+	<string name="menu_displaytrack">Vis spor</string>
+	<string name="menu_stoptracking">Stopp &amp; lagre</string>
+	<string name="menu_newtrack">Nytt spor</string>
+	<string name="menu_deletetracks">Slett alle spor</string>
+	<string name="menu_continue">Fortsett spor</string>
+	<string name="menu_save">Lagre</string>
+	<string name="menu_cancel">Avbryt</string>
+	<string name="menu_export">Eksporter som GPX</string>
+	<string name="menu_center_to_gps">Sentrer på GPS</string>
+	
+	<!-- Errors -->
+	<string name="error_externalstorage_not_writable">Kan ikke skrive til ekstern lagringsenhet.</string>
+	<string name="error_externalstorage_not_writable_hint">Sjekk om ekstern lagringsenhet er skikkelig satt inn i mobilen og aktivert.</string>
+	<string name="error_voicerec_failed">Stemmeopptak fungerte ikke</string>
+	<string name="error_userlayout_parsing">Feil ved tolking av XML-layoutfil. Bruk heller standard layout.</string>
+
+	<!-- GPX -->
+	<string name="gpx_track_name">Spora med OSMTracker for Android™</string>
+	<string name="gpx_hdop_approximation_cmt">Advarsel: HDOP-verdier er ikke HDOP-verdiene fra selve GPS-enheten. De er estimerte fra posisjonspresisjon.</string>
+
+	<!-- About screen -->
+	<string name="about">Om</string>
+	<string name="about_text">Besøk prosjektheimesida for mer informasjon, dokumentasjon og feilmelding:</string>
+	<string name="about_link"><a href="http://osmtracker-android.googlecode.com/">http://osmtracker-android.googlecode.com/</a></string>
+	<string name="about_debug_info">Debug info</string>
+
+	<!-- Notification -->
+	<string name="notification_ticker_text">OSMTracker sporer</string>
+	<string name="notification_title">OSMTracker sporer (nr. {0})</string>
+	<string name="notification_text">Trykk her for hovedskjermbilde</string>
+
+	<!-- Display track -->
+	<string name="displaytrack">Vis spor</string>	
+	<string name="displaytrack_north">N</string>
+	
+	<!-- Track detail -->
+	<string name="trackdetail_save">Lagre</string>
+	
+	<!-- Various -->
+	<string name="various_unit_meters">m</string>
+	<string name="various_accuracy">Presisjon</string>
+	<string name="various_waiting_gps_fix">Venter på GPS-posisjon&#8230;</string>
+
+	<!-- OSM map view -->
+	<string name="displaytrackmap">OpenStreetMap sporvising</string> 
+
+</resources>

--- a/res/values-no/waypoints.xml
+++ b/res/values-no/waypoints.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="wpt_voicerec">Stemmeopptak</string>
+	<string name="wpt_stillimage">Foto</string>
+</resources>

--- a/res/xml-nb/README.txt
+++ b/res/xml-nb/README.txt
@@ -1,0 +1,1 @@
+nb and no locale are the same, please synchronize any changes between the two.

--- a/res/xml-no/README.txt
+++ b/res/xml-no/README.txt
@@ -1,0 +1,1 @@
+nb and no locale are the same, please synchronize any changes between the two.

--- a/res/xml-no/default_buttons_layout.xml
+++ b/res/xml-no/default_buttons_layout.xml
@@ -1,0 +1,241 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<layouts>
+	<layout name="root">
+		<row>
+			<button type="voicerec" icon="voice_32x32" />
+			<button type="picture" icon="camera_32x32" />
+			<button type="textnote" icon="text_32x32" />
+		</row>
+		
+		<row>
+			<button type="page" label="Diverse" icon="button_misc" targetlayout="misc" />
+			<button type="page" label="Restriksjon" icon="button_restriction" targetlayout="restriction" />
+			<button type="page" label="Bil" icon="button_car" targetlayout="car" />
+		</row>
+		<row>
+			<button type="page" label="Turisme" icon="button_tourism" targetlayout="tourism" />
+			<button type="page" label="Fasiliteter 1" icon="button_amenity" targetlayout="amenity" />
+			<button type="page" label="Fasiliteter 2" icon="button_amenity" targetlayout="amenity_more" />
+		</row>
+		<row>
+			<button type="page" label="Veg" icon="button_way" targetlayout="way" />
+			<button type="page" label="Spor" icon="button_track" targetlayout="track" />
+			<button type="page" label="Bruk av land" icon="button_landuse" targetlayout="landuse" />
+		</row>
+	</layout>
+
+	<layout name="misc">
+		<row>
+			<button type="voicerec" icon="voice_32x32" />
+			<button type="picture" icon="camera_32x32" />
+			<button type="textnote" icon="text_32x32" />
+		</row>
+		<row>
+			<button type="tag" label="Busstopp" icon="button_misc_bus_stop" />
+			<button type="tag" label="Jernbane" icon="button_misc_railway" />
+			<button type="tag" label="Telefon" icon="button_misc_telephone" />
+		</row>
+		<row>
+			<button type="tag" label="Postboks" icon="button_misc_post_box" />
+			<button type="tag" label="Minibank" icon="button_misc_atm" />
+			<button type="tag" label="Bom" icon="button_misc_bollard" />
+		</row>
+		<row>
+			<button type="tag" label="Do" icon="button_misc_toilets" />
+			<button type="tag" label="Leskur" icon="button_misc_shelter" />
+			<button type="tag" label="Overvåking" icon="button_misc_surveillance" />
+		</row>
+	</layout>
+
+	<layout name="restriction">
+		<row>
+			<button type="voicerec" icon="voice_32x32" />
+			<button type="picture" icon="camera_32x32" />
+			<button type="textnote" icon="text_32x32" />
+		</row>
+		<row>
+			<button type="tag" label="Maks 30" icon="button_restriction" />
+			<button type="tag" label="Maks 40" icon="button_restriction" />
+			<button type="tag" label="Maks 50" icon="button_restriction" />
+		</row>
+		<row>
+			<button type="tag" label="Maks 60" icon="button_restriction" />
+			<button type="tag" label="Maks 70" icon="button_restriction" />
+			<button type="tag" label="Maks 80" icon="button_restriction" />
+		</row>
+		<row>
+			<button type="tag" label="Ingen utgang" icon="button_restriction_no_exit" />
+			<button type="tag" label="Trafikklys" icon="button_restriction_traffic_light" />
+			<button type="tag" label="Envegs" icon="button_restriction_one_way" />
+		</row>
+	</layout>
+
+	<layout name="car">
+		<row>
+			<button type="voicerec" icon="voice_32x32" />
+			<button type="picture" icon="camera_32x32" />
+			<button type="textnote" icon="text_32x32" />
+		</row>
+		<row>
+			<button type="tag" label="Bensinstasjon" icon="button_car_fuel_station" />
+			<button type="tag" label="Parkering" icon="button_car_parking" />
+			<button type="tag" label="Nødtelefon" icon="button_car_emergency_phone" />
+		</row>
+		<row>
+			<button type="tag" label="Snuplass" icon="button_car_turning_circle" />
+			<button type="tag" label="Fotoboks" icon="button_car_speed_camera" />
+		</row>
+	</layout>
+
+	<layout name="tourism">
+		<row>
+			<button type="voicerec" icon="voice_32x32" />
+			<button type="picture" icon="camera_32x32" />
+			<button type="textnote" icon="text_32x32" />
+		</row>
+		<row>
+			<button type="tag" label="Utsiktspunkt" icon="button_tourism_view_point" />
+			<button type="tag" label="Informasjon" icon="button_tourism_information" />
+			<button type="tag" label="Rasteplass" icon="button_tourism_picnic" />
+		</row>
+		<row>
+			<button type="tag" label="Attraksjon" icon="button_tourism_attraction" />
+			<button type="tag" label="Fornøyelsespark" icon="button_tourism_theme_park" />
+			<button type="tag" label="Slott" icon="button_tourism_castle" />
+		</row>
+		<row>
+			<button type="tag" label="Monument" icon="button_tourism_monument" />
+			<button type="tag" label="Museum" icon="button_tourism_museum" />
+			<button type="tag" label="Kino" icon="button_tourism_cinema" />
+		</row>
+	</layout>
+
+	<layout name="amenity">
+		<row>
+			<button type="voicerec" icon="voice_32x32" />
+			<button type="picture" icon="camera_32x32" />
+			<button type="textnote" icon="text_32x32" />
+		</row>
+		<row>
+			<button type="tag" label="Benk" icon="button_amenity_bench" />
+			<button type="tag" label="Vann" icon="button_amenity_water" />
+			<button type="tag" label="Apotek" icon="button_amenity_pharmacy" />
+		</row>
+		<row>
+			<button type="tag" label="Butikk" icon="button_amenity_shop" />
+			<button type="tag" label="Marina" icon="button_amenity_marina" />
+			<button type="tag" label="Sport" icon="button_amenity_sport" />
+		</row>
+		<row>
+			<button type="tag" label="Drosje" icon="button_amenity_taxi" />
+			<button type="tag" label="Sjukehus,\nLege" icon="button_amenity_doctors" />
+			<button type="tag" label="Resirkulering" icon="button_amenity_recycling" />
+		</row>
+		<row>
+			<button type="tag" label="Gudshus" icon="button_amenity_place_of_worship" />
+			<button type="tag" label="Postkontor" icon="button_amenity_post_office" />
+			<button type="tag" label="Bibliotek" icon="button_amenity_library" />
+		</row>
+	</layout>
+
+	<layout name="amenity_more">
+		<row>
+			<button type="voicerec" icon="voice_32x32" />
+			<button type="picture" icon="camera_32x32" />
+			<button type="textnote" icon="text_32x32" />
+		</row>
+		<row>
+			<button type="tag" label="Skole" icon="button_amenitymore_school" />
+			<button type="tag" label="Politi" icon="button_amenitymore_police" />
+			<button type="tag" label="Brannstasjon" icon="button_amenitymore_fire_station" />
+		</row>
+		<row>
+			<button type="tag" label="Bank" icon="button_amenitymore_bank" />
+			<button type="tag" label="Lekeplass" icon="button_amenitymore_playground" />
+			<button type="tag" label="Pub" icon="button_amenitymore_pub" />
+		</row>
+		<row>
+			<button type="tag" label="Hotell" icon="button_amenitymore_hotel" />
+			<button type="tag" label="Pensjonat" icon="button_amenitymore_motel" />
+			<button type="tag" label="Vandrerheim" icon="button_amenitymore_hostel" />
+		</row>
+		<row>
+			<button type="tag" label="Restaurant" icon="button_amenitymore_restaurant" />
+			<button type="tag" label="Hurtigmat" icon="button_amenitymore_fastfood" />
+			<button type="tag" label="Camping" icon="button_amenitymore_camp_site" />
+		</row>
+	</layout>
+
+	<layout name="way">
+		<row>
+			<button type="voicerec" icon="voice_32x32" />
+			<button type="picture" icon="camera_32x32" />
+			<button type="textnote" icon="text_32x32" />
+		</row>
+		<row>
+			<button type="tag" label="Bru" icon="button_way_bridge" />
+			<button type="tag" label="Fotgjengerovergang" icon="button_way_zebra_crossing" />
+			<button type="tag" label="Motorveg" icon="button_way_motorway" />
+		</row>
+		<row>
+			<button type="tag" label="Riksveg" icon="button_way_trunk" />
+			<button type="tag" label="Skilta\nfylkesveg" icon="button_way_primary" />
+			<button type="tag" label="Uskilta\nfylkesveg" icon="button_way_secondary" />
+		</row>
+		<row>
+			<button type="tag" label="Lokal\nveg" icon="button_way_tertiary" />
+			<button type="tag" label="Bustadområde-\nveg" icon="button_way_residential" />
+			<button type="tag" label="Adkomstveg" icon="button_way_service" />
+		</row>
+	</layout>
+
+	<layout name="track">
+		<row>
+			<button type="voicerec" icon="voice_32x32" />
+			<button type="picture" icon="camera_32x32" />
+			<button type="textnote" icon="text_32x32" />
+		</row>
+		<row>
+			<button type="tag" label="Spor" icon="button_track_track" />
+			<button type="tag" label="Sykkelveg" icon="button_track_cycleway" />
+			<button type="tag" label="Gangveg" icon="button_track_footway" />
+		</row>
+		<row>
+			<button type="tag" label="Rideveg" icon="button_track_bridleway" />
+			<button type="tag" label="Trinn" icon="button_track_steps" />
+			<button type="tag" label="Gågate" icon="button_track_living_street" />
+		</row>
+		<row>
+			<button type="tag" label="Fotgjenger" icon="button_track_pedestrian" />
+			<button type="tag" label="Grad 1" icon="button_track_grade1" />
+			<button type="tag" label="Grad 2" icon="button_track_grade2" />
+		</row>
+		<row>
+			<button type="tag" label="Grad 3" icon="button_track_grade3" />
+			<button type="tag" label="Grad 4" icon="button_track_grade4" />
+			<button type="tag" label="Grad 5" icon="button_track_grade5" />
+		</row>
+	</layout>
+
+	<layout name="landuse">
+		<row>
+			<button type="voicerec" icon="voice_32x32" />
+			<button type="picture" icon="camera_32x32" />
+			<button type="textnote" icon="text_32x32" />
+		</row>
+		<row>
+			<button type="tag" label="Gard" icon="button_landuse_farm" />
+			<button type="tag" label="Bossfylling" icon="button_landuse_landfill" />
+			<button type="tag" label="Basseng" icon="button_landuse_basin" />
+		</row>
+		<row>
+			<button type="tag" label="Vassmagasin" icon="button_landuse_reservoir" />
+			<button type="tag" label="Skog" icon="button_landuse_forest" />
+			<button type="tag" label="Parsell" icon="button_landuse_allotments" />
+		</row>
+		<row>
+			<button type="tag" label="Gravplass" icon="button_landuse_cemetery" />
+			<button type="tag" label="Rekreasjonsplass" icon="button_landuse_recreation_ground" />
+		</row>
+	</layout>
+</layouts>


### PR DESCRIPTION
It seems Norwegian language support isn't ideal in Android. There are two written forms of Norwegian, which each have their own ISO code: Norwegian bokmål (nb) and Norwegian Nynorsk (nn). Unfortunately "Norwegian" without any for specification also has an ISO code: no.

By law they are equal in Norway, but in practice, bokmål is far more prevalent and in use (80-90 % of written text is probably bokmål).

It seems both no and nb are used in Android: http://stackoverflow.com/questions/5153674/android-localization-question

The only practical way to solve this seems to be to have two copies of Norwegian bokmål, one under "nb" and one under "no". Symbolic links are not supported on FAT filesystems, and thus the app cant be moved to memory cards, string aliases doesn't seem to be practical as one would still need to make the string files containing aliases(?), and I don't know of any way to "prioritize" languages (if no "no", then use "nb").

I've added a readme file to all folders containing nb and no noting that they should be kept in sync.

The "nb" Android market text should probably also be copied to "no".
