### PR TITLE
TrackContentProvider allow custom queries

### DIFF
--- a/src/me/guillaumin/android/osmtracker/db/TrackContentProvider.java
+++ b/src/me/guillaumin/android/osmtracker/db/TrackContentProvider.java
@@ -175,11 +175,17 @@ public class TrackContentProvider extends ContentProvider {
 		return count;
 	}
 
+	/**
+	 * Match and get the URI type, if recognized:
+	 * Matches {@link Schema#URI_CODE_TRACK_TRACKPOINTS}, {@link Schema#URI_CODE_TRACK_WAYPOINTS},
+	 * or {@link Schema#URI_CODE_TRACK}.
+	 * @throws IllegalArgumentException if not matched
+	 */
 	@Override
-	public String getType(Uri uri) {
+	public String getType(Uri uri) throws IllegalArgumentException {
 		Log.v(TAG, "getType(), uri=" + uri);
 
-		// Select wich type to return
+		// Select which type to return
 		switch (uriMatcher.match(uri)) {
 		case Schema.URI_CODE_TRACK_TRACKPOINTS:
 			return ContentResolver.CURSOR_DIR_BASE_TYPE + "/vnd." + OSMTracker.class.getPackage() + "."
@@ -190,8 +196,9 @@ public class TrackContentProvider extends ContentProvider {
 		case Schema.URI_CODE_TRACK:
 			return ContentResolver.CURSOR_DIR_BASE_TYPE + "/vnd." + OSMTracker.class.getPackage() + "."
 					+ Schema.TBL_TRACK;
+		default:
+			throw new IllegalArgumentException("Unknown URL " + uri);
 		}
-		return null;
 	}
 
 	@Override


### PR DESCRIPTION
Minor changes to help coding custom queries against this provider.
- getType: Throw if uri not recognized; I found this is easier to debug than a NullPointerException later, if I've made a typo or mistake constructing my uri
- query: use custom projection if provided; allows control of the set of returned columns
