### PR TITLE
Issue #105 Setting to choose other tile provider for OSM map 

### DIFF
--- a/res/values/strings-preferences.xml
+++ b/res/values/strings-preferences.xml
@@ -81,5 +81,13 @@
 	<string name="prefs_osm_clear_oauth_data">Reset OSM authentication</string>
 	<string name="prefs_osm_clear_oauth_data_summary">Forget OSM credentials and permissions and force OSMTracker to ask them again</string>
 	<string name="prefs_osm_clear_oauth_data_dialog">You\'ll have to authorize OSMTracker to upload tracks again. Are you sure?</string>
+	
+	<string name="prefs_map_tile">Map Tile provider</string>
+    <string name="prefs_map_tile_summary"></string>
+	<string-array name="prefs_map_tile_keys">
+        <item>MAPNIK</item>
+        <item>CYCLEMAP</item>
+        <item>MAPQUESTOSM</item>
+    </string-array>
 
 </resources>

--- a/res/values/values-preferences.xml
+++ b/res/values/values-preferences.xml
@@ -35,5 +35,11 @@
 		<item>wpt_name</item>
 		<item>wpt_cmt</item>
 	</string-array>
+	
+	<string-array name="prefs_map_tile_values">
+        <item>MAPNIK</item>
+        <item>CYCLEMAP</item>
+        <item>MAPQUESTOSM</item>
+    </string-array>
 
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -50,6 +50,8 @@
 			android:summary="@string/prefs_displaytrack_osm_summary" android:defaultValue="false"></CheckBoxPreference>
 		<ListPreference android:defaultValue="none" android:key="ui.orientation" android:title="@string/prefs_ui_orientation"
 			android:summary="@string/prefs_ui_orientation_summary" android:entries="@array/prefs_ui_orientation_options_keys" android:entryValues="@array/prefs_ui_orientation_options_values"></ListPreference>
+		<ListPreference android:entries="@array/prefs_map_tile_keys" android:title="@string/prefs_map_tile"
+            android:entryValues="@array/prefs_map_tile_values" android:key="ui.map.tile" android:summary="@string/prefs_map_tile_summary" android:defaultValue="MAPNIK"></ListPreference>
 	</PreferenceCategory>
 
 

--- a/src/me/guillaumin/android/osmtracker/OSMTracker.java
+++ b/src/me/guillaumin/android/osmtracker/OSMTracker.java
@@ -29,11 +29,13 @@ public class OSMTracker {
 		public final static String KEY_UI_BUTTONS_LAYOUT = "ui.buttons.layout";
 		public final static String KEY_UI_DISPLAYTRACK_OSM = "ui.displaytrack.osm";
 		public final static String KEY_UI_DISPLAY_KEEP_ON = "ui.display_keep_on";
+		public final static String KEY_UI_MAP_TILE = "ui.map.tile";
 		public final static String KEY_SOUND_ENABLED = "sound_enabled";
 		public final static String KEY_UI_ORIENTATION = "ui.orientation";
 		public final static String KEY_OSM_OAUTH_TOKEN = "osm.oauth.token";
 		public final static String KEY_OSM_OAUTH_SECRET = "osm.oauth.secret";
 		public final static String KEY_OSM_OAUTH_CLEAR_DATA = "osm.oauth.clear-data";
+		
 
 		// Default values
 		public final static String VAL_STORAGE_DIR = "/osmtracker";
@@ -64,6 +66,11 @@ public class OSMTracker {
 		public final static String VAL_UI_ORIENTATION_PORTRAIT = "portrait";
 		public final static String VAL_UI_ORIENTATION_LANDSCAPE = "landscape";
 		public final static String VAL_UI_ORIENTATION = VAL_UI_ORIENTATION_NONE;
+		
+		public final static String VAL_UI_MAP_TILE_MAPNIK = "MAPNIK";
+		public final static String VAL_UI_MAP_TILE_CYCLEMAP = "CYCLEMAP";
+		public final static String VAL_UI_MAP_TILE_MAPQUESTOSM = "MAPQUESTOSM";
+		
 	};
 	
 	/**

--- a/src/me/guillaumin/android/osmtracker/activity/DisplayTrackMap.java
+++ b/src/me/guillaumin/android/osmtracker/activity/DisplayTrackMap.java
@@ -10,6 +10,8 @@ import me.guillaumin.android.osmtracker.db.TrackContentProvider.Schema;
 import me.guillaumin.android.osmtracker.overlay.WayPointsOverlay;
 
 import org.osmdroid.contributor.util.constants.OpenStreetMapContributorConstants;
+import org.osmdroid.tileprovider.tilesource.ITileSource;
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.BoundingBoxE6;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapController;
@@ -182,6 +184,8 @@ public class DisplayTrackMap extends Activity implements OpenStreetMapContributo
         	SharedPreferences settings = getPreferences(MODE_PRIVATE);
         	osmViewController.setZoom(settings.getInt(LAST_ZOOM, DEFAULT_ZOOM));
         }
+        
+        selectTileSource();
 
         createOverlays();
 
@@ -207,8 +211,34 @@ public class DisplayTrackMap extends Activity implements OpenStreetMapContributo
 			}
         });
    }
+
+    	/**
+    	 * Sets the map tile provider according to the user's demands in the settings.
+    	 */
+	public void selectTileSource() {
+		String mapTile = prefs.getString(OSMTracker.Preferences.KEY_UI_MAP_TILE, OSMTracker.Preferences.VAL_UI_MAP_TILE_MAPNIK);
+		osmView.setTileSource(selectMapTile(mapTile));
+	}
     
-    
+	/**
+	 * Returns a ITileSource for the map according to the selected mapTile
+	 * String. The default is mapnik.
+	 * 
+	 * @param mapTile
+	 *                String that is the name of the tile provider
+	 * @return ITileSource with the selected Tile-Source
+	 */
+	private ITileSource selectMapTile(String mapTile) {
+
+		if (mapTile.equals(OSMTracker.Preferences.VAL_UI_MAP_TILE_CYCLEMAP))
+			return TileSourceFactory.CYCLEMAP;
+		else if (mapTile.equals(OSMTracker.Preferences.VAL_UI_MAP_TILE_MAPQUESTOSM))
+			return TileSourceFactory.MAPQUESTOSM;
+		else
+			return TileSourceFactory.MAPNIK;
+	}
+
+
 	@Override
 	protected void onSaveInstanceState(Bundle outState) {
 		outState.putInt(CURRENT_ZOOM, osmView.getZoomLevel());
@@ -238,6 +268,8 @@ public class DisplayTrackMap extends Activity implements OpenStreetMapContributo
 		
         // Reload path
         pathChanged();
+
+         selectTileSource();
         
         // Refresh way points
         // wayPointsOverlay.refresh();


### PR DESCRIPTION
add setting to select map tile provider. this allows the user to choose between mapnik (default), cyclemap and mapquestosm.

sadly, the other tile providers do not seem to work anymore (URL changed?).
