### PR TITLE
Added track sharing feature

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,12 @@
 		    android:authorities="me.guillaumin.android.osmtracker.provider"
 		    android:exported="false" />
 
+		<provider
+			android:name="me.guillaumin.android.osmtracker.gpx.TrackFileProvider"
+			android:authorities="me.guillaumin.android.osmtracker.fileshareprovider"
+			android:exported="false"
+			android:grantUriPermissions="true"/>
+
 		<receiver android:name=".receiver.MediaButtonReceiver" >
 	        <intent-filter>
 	            <action android:name="android.intent.action.MEDIA_BUTTON" />               

--- a/app/src/main/java/me/guillaumin/android/osmtracker/activity/TrackDetail.java
+++ b/app/src/main/java/me/guillaumin/android/osmtracker/activity/TrackDetail.java
@@ -209,7 +209,10 @@ public class TrackDetail extends TrackDetailEditor implements AdapterView.OnItem
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
 		Intent i;
-		
+		SimpleAdapter adapter;
+		@SuppressWarnings("unchecked")
+		Map<String, String> data;
+
 		switch(item.getItemId()) {
 		case R.id.trackdetail_menu_save:
 			save();
@@ -233,20 +236,18 @@ public class TrackDetail extends TrackDetailEditor implements AdapterView.OnItem
 		case R.id.trackdetail_menu_export:
 			new ExportToStorageTask(this, trackId).execute();
 			// Pick last list item (Exported date) and update it
-			SimpleAdapter adapter = ((SimpleAdapter) lv.getAdapter());
-			@SuppressWarnings("unchecked")
-			Map<String, String> data = (Map<String, String>) adapter.getItem(adapter.getCount()-1);
+			adapter = ((SimpleAdapter) lv.getAdapter());
+			data = (Map<String, String>) adapter.getItem(adapter.getCount()-1);
 			data.put(ITEM_VALUE, DateFormat.getDateTimeInstance().format(new Date(System.currentTimeMillis())));
 			adapter.notifyDataSetChanged();
 			break;
 		case R.id.trackdetail_menu_share:
 			new ExportAndShareTask(this, trackId).execute();
 			// Pick last list item (Exported date) and update it
-			SimpleAdapter adapter1 = ((SimpleAdapter) lv.getAdapter());
-			@SuppressWarnings("unchecked")
-			Map<String, String> data1 = (Map<String, String>) adapter1.getItem(adapter1.getCount()-1);
-			data1.put(ITEM_VALUE, DateFormat.getDateTimeInstance().format(new Date(System.currentTimeMillis())));
-			adapter1.notifyDataSetChanged();
+			adapter = ((SimpleAdapter) lv.getAdapter());
+			data = (Map<String, String>) adapter.getItem(adapter.getCount()-1);
+			data.put(ITEM_VALUE, DateFormat.getDateTimeInstance().format(new Date(System.currentTimeMillis())));
+			adapter.notifyDataSetChanged();
 			break;
 		case R.id.trackdetail_menu_osm_upload:
 			i = new Intent(this, OpenStreetMapUpload.class);
@@ -308,5 +309,14 @@ public class TrackDetail extends TrackDetailEditor implements AdapterView.OnItem
 		}
 
 	}  // inner class TrackDetailSimpleAdapter
+
+    /**
+     * Clean up the temp file after it was shared with external app
+     */
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        ExportAndShareTask.deleteSharedFile(requestCode);
+    }
 
 }  // public class TrackDetail

--- a/app/src/main/java/me/guillaumin/android/osmtracker/activity/TrackDetail.java
+++ b/app/src/main/java/me/guillaumin/android/osmtracker/activity/TrackDetail.java
@@ -12,6 +12,7 @@ import me.guillaumin.android.osmtracker.R;
 import me.guillaumin.android.osmtracker.db.TrackContentProvider;
 import me.guillaumin.android.osmtracker.db.TrackContentProvider.Schema;
 import me.guillaumin.android.osmtracker.db.model.Track;
+import me.guillaumin.android.osmtracker.gpx.ExportAndShareTask;
 import me.guillaumin.android.osmtracker.gpx.ExportToStorageTask;
 import me.guillaumin.android.osmtracker.util.MercatorProjection;
 import android.content.ContentResolver;
@@ -237,6 +238,15 @@ public class TrackDetail extends TrackDetailEditor implements AdapterView.OnItem
 			Map<String, String> data = (Map<String, String>) adapter.getItem(adapter.getCount()-1);
 			data.put(ITEM_VALUE, DateFormat.getDateTimeInstance().format(new Date(System.currentTimeMillis())));
 			adapter.notifyDataSetChanged();
+			break;
+		case R.id.trackdetail_menu_share:
+			new ExportAndShareTask(this, trackId).execute();
+			// Pick last list item (Exported date) and update it
+			SimpleAdapter adapter1 = ((SimpleAdapter) lv.getAdapter());
+			@SuppressWarnings("unchecked")
+			Map<String, String> data1 = (Map<String, String>) adapter1.getItem(adapter1.getCount()-1);
+			data1.put(ITEM_VALUE, DateFormat.getDateTimeInstance().format(new Date(System.currentTimeMillis())));
+			adapter1.notifyDataSetChanged();
 			break;
 		case R.id.trackdetail_menu_osm_upload:
 			i = new Intent(this, OpenStreetMapUpload.class);

--- a/app/src/main/java/me/guillaumin/android/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/me/guillaumin/android/osmtracker/activity/TrackManager.java
@@ -10,6 +10,7 @@ import me.guillaumin.android.osmtracker.db.TrackContentProvider;
 import me.guillaumin.android.osmtracker.db.TrackContentProvider.Schema;
 import me.guillaumin.android.osmtracker.db.TracklistAdapter;
 import me.guillaumin.android.osmtracker.exception.CreateTrackException;
+import me.guillaumin.android.osmtracker.gpx.ExportAndShareTask;
 import me.guillaumin.android.osmtracker.gpx.ExportToStorageTask;
 import me.guillaumin.android.osmtracker.util.FileSystemUtils;
 import android.app.AlertDialog;
@@ -281,7 +282,7 @@ public class TrackManager extends ListActivity {
 			menu.findItem(R.id.trackmgr_contextmenu_stop).setVisible(false);
 		}
 		menu.setHeaderTitle(getResources().getString(R.string.trackmgr_contextmenu_title).replace("{0}", Long.toString(selectedId)));
-		if ( currentTrackId ==  selectedId) {
+		if ( currentTrackId == selectedId) {
 			// User has pressed the active track, hide the delete option
 			menu.removeItem(R.id.trackmgr_contextmenu_delete);
 		}
@@ -330,6 +331,9 @@ public class TrackManager extends ListActivity {
 			break;
 		case R.id.trackmgr_contextmenu_export:	
 			new ExportToStorageTask(this, info.id).execute();
+			break;
+		case R.id.trackmgr_contextmenu_share:
+			new ExportAndShareTask(this, info.id).execute();
 			break;
 		case R.id.trackmgr_contextmenu_osm_upload:
 			i = new Intent(this, OpenStreetMapUpload.class);
@@ -382,7 +386,7 @@ public class TrackManager extends ListActivity {
 
 	/**
 	 * Creates a new track, in DB and on SD card
-	 * @returns The ID of the new track
+	 * @return The ID of the new track
 	 * @throws CreateTrackException
 	 */
 	private long createNewTrack() throws CreateTrackException {
@@ -404,7 +408,7 @@ public class TrackManager extends ListActivity {
 	
 	/**
 	 * Deletes the track with the specified id from DB and SD card
-	 * @param The ID of the track to be deleted
+	 * @param id The ID of the track to be deleted
 	 */
 	private void deleteTrack(long id) {
 		getContentResolver().delete(
@@ -475,5 +479,13 @@ public class TrackManager extends ListActivity {
 			
 		}
 	}
-	
+
+    /**
+	 * Clean up the temp file after it was shared with external app
+     */
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+		ExportAndShareTask.deleteSharedFile(requestCode);
+    }
 }

--- a/app/src/main/java/me/guillaumin/android/osmtracker/db/DataHelper.java
+++ b/app/src/main/java/me/guillaumin/android/osmtracker/db/DataHelper.java
@@ -43,6 +43,11 @@ public class DataHelper {
 	public static final String EXTENSION_JPG = ".jpg";
 
 	/**
+	 * ZIP file extension
+	 */
+	public static final String EXTENSION_ZIP = ".zip";
+
+	/**
 	 * Number of tries to rename a media file for the current track if there are
 	 * already a media file of this name.
 	 */

--- a/app/src/main/java/me/guillaumin/android/osmtracker/gpx/ExportAndShareTask.java
+++ b/app/src/main/java/me/guillaumin/android/osmtracker/gpx/ExportAndShareTask.java
@@ -1,0 +1,97 @@
+package me.guillaumin.android.osmtracker.gpx;
+
+import android.app.AlertDialog;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.database.Cursor;
+import android.net.Uri;
+import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.TreeMap;
+
+import me.guillaumin.android.osmtracker.R;
+import me.guillaumin.android.osmtracker.exception.ExportTrackException;
+
+/**
+ * Exports to a a temporary file, then shares intent with uri
+ */
+
+public class ExportAndShareTask extends ExportTrackTask {
+    private static final String TAG = ExportToTempFileTask.class.getSimpleName();
+
+    static final TreeMap<String, File> sharedFiles = new TreeMap<String, File>();
+    final File tmpFile;
+    String filename;
+
+    public ExportAndShareTask(Context context, long trackId) {
+        super(context, trackId);
+        try {
+            tmpFile = File.createTempFile("shared-track", ".gpx", context.getCacheDir());
+            Log.d(TAG, "Temporary file: " + tmpFile.getAbsolutePath());
+        } catch (IOException ioe) {
+            Log.e(TAG, "Could not create temporary file", ioe);
+            throw new IllegalStateException("Could not create temporary file", ioe);
+        }
+    }
+
+    /**
+     * @param startDate
+     * @return The directory in which the track file should be created
+     * @throws ExportTrackException
+     */
+    @Override
+    protected File getExportDirectory(Date startDate) throws ExportTrackException {
+        return tmpFile.getParentFile();
+    }
+
+    /**
+     * Whereas to export the media files or not
+     *
+     * @return
+     */
+    @Override
+    protected boolean exportMediaFiles() {
+        return false;
+    }
+
+    @Override
+    protected String buildGPXFilename(Cursor c) {
+        filename = super.buildGPXFilename(c);
+        return tmpFile.getName();
+    }
+
+    /**
+     * Whereas to update the track export date in the database at the end or not
+     *
+     * @return
+     */
+    @Override
+    protected boolean updateExportDate() {
+        return false;
+    }
+
+    @Override
+    protected void onPostExecute(Boolean success) {
+        super.onPostExecute(success);
+        sharedFiles.put(filename, tmpFile);
+        Uri tempFileUri = Uri.parse("content://me.guillaumin.android.osmtracker.fileshareprovider/" + filename);
+        Intent shareTrack = new Intent(Intent.ACTION_SEND);
+        shareTrack.setType("application/xml");
+        shareTrack.putExtra(Intent.EXTRA_STREAM, tempFileUri);
+
+        PackageManager packageManager = context.getPackageManager();
+        if (packageManager.queryIntentActivities(shareTrack, PackageManager.MATCH_DEFAULT_ONLY).size() > 0)
+            context.startActivity(shareTrack);
+        else
+        {
+            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);
+            dialogBuilder.setMessage(context.getResources().getString(R.string.error_no_appropriate_activity));
+            AlertDialog dialog = dialogBuilder.create();
+            dialog.show();
+        }
+    }
+}

--- a/app/src/main/java/me/guillaumin/android/osmtracker/gpx/ExportAndShareTask.java
+++ b/app/src/main/java/me/guillaumin/android/osmtracker/gpx/ExportAndShareTask.java
@@ -8,33 +8,53 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.util.Log;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Date;
 import java.util.TreeMap;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import me.guillaumin.android.osmtracker.R;
 import me.guillaumin.android.osmtracker.exception.ExportTrackException;
 
 /**
- * Exports to a a temporary file, then shares intent with uri
+ * Exports the track and media (if any) to a a temporary file, then shares it with another app
  */
 
 public class ExportAndShareTask extends ExportTrackTask {
     private static final String TAG = ExportToTempFileTask.class.getSimpleName();
 
+    /**
+     * Maps from name that is passed in URI to another app to a real file in the cache dir.
+     */
     static final TreeMap<String, File> sharedFiles = new TreeMap<String, File>();
-    final File tmpFile;
-    String filename;
+    /**
+     * Name of the file, passed to another app in URI.
+     */
+    private String filename;
+    /**
+     * Subfolder in cacheDir, where track is exported
+     */
+    private File trackDir;
 
     public ExportAndShareTask(Context context, long trackId) {
         super(context, trackId);
-        try {
-            tmpFile = File.createTempFile("shared-track", ".gpx", context.getCacheDir());
-            Log.d(TAG, "Temporary file: " + tmpFile.getAbsolutePath());
-        } catch (IOException ioe) {
-            Log.e(TAG, "Could not create temporary file", ioe);
-            throw new IllegalStateException("Could not create temporary file", ioe);
+        File cacheDir = context.getCacheDir();
+        // Generate name for a temporary directory
+        trackDir = new File(cacheDir, "trackDirectory");
+        int i = 0;
+        while (trackDir.exists())
+            trackDir = new File(cacheDir, "trackDirectory" + i++);
+        if (trackDir.mkdir())
+            Log.d(TAG, "Temporary file: " + trackDir.getAbsolutePath());
+        else {
+            Log.e(TAG, "Could not create temporary directory");
+            throw new IllegalStateException("Could not create temporary directory");
         }
     }
 
@@ -45,7 +65,7 @@ public class ExportAndShareTask extends ExportTrackTask {
      */
     @Override
     protected File getExportDirectory(Date startDate) throws ExportTrackException {
-        return tmpFile.getParentFile();
+        return trackDir;
     }
 
     /**
@@ -55,13 +75,13 @@ public class ExportAndShareTask extends ExportTrackTask {
      */
     @Override
     protected boolean exportMediaFiles() {
-        return false;
+        return true;
     }
 
     @Override
     protected String buildGPXFilename(Cursor c) {
         filename = super.buildGPXFilename(c);
-        return tmpFile.getName();
+        return filename;
     }
 
     /**
@@ -71,13 +91,64 @@ public class ExportAndShareTask extends ExportTrackTask {
      */
     @Override
     protected boolean updateExportDate() {
-        return false;
+        return true;
     }
 
     @Override
     protected void onPostExecute(Boolean success) {
         super.onPostExecute(success);
-        sharedFiles.put(filename, tmpFile);
+
+        File cacheDir = context.getCacheDir();
+        File fileToShare;
+        File[] generatedFiles = trackDir.listFiles();
+        boolean a;
+        if (generatedFiles.length == 1) {
+            // if there's only one file in the directory - move file to cache root and share it
+            fileToShare = new File(cacheDir, "track-to-share.gpx");
+            int i = 0;
+            while (fileToShare.exists())
+                fileToShare = new File(cacheDir, "track-to-share" + i++ + ".gpx");
+            if (generatedFiles[0].renameTo(fileToShare))
+                a = trackDir.delete();
+            else
+                // in some strange situation, when file can't be moved
+                fileToShare = generatedFiles[0];
+        }
+        else if (generatedFiles.length > 1) {
+            // if there are several files - put them into zip and share it
+            try {
+                if (filename.endsWith(".gpx"))
+                    filename = filename.substring(0, filename.length() - 4);
+                filename = filename + ".zip";
+                fileToShare = File.createTempFile("track-to-share", ".zip", cacheDir);
+                BufferedInputStream bufferedInputStream;
+                byte[] buffer = new byte[4096];
+                int count;
+                FileOutputStream outputStream = new FileOutputStream(fileToShare);
+                ZipOutputStream zipOut = new ZipOutputStream(new BufferedOutputStream(outputStream));
+                for (File f : generatedFiles) {
+                    ZipEntry entry = new ZipEntry(f.getName());
+                    zipOut.putNextEntry(entry);
+                    bufferedInputStream = new BufferedInputStream(new FileInputStream(f));
+                    while ((count = bufferedInputStream.read(buffer, 0, buffer.length)) > -1)
+                        zipOut.write(buffer, 0, count);
+                    bufferedInputStream.close();
+                    f.delete();
+                }
+                zipOut.close();
+                trackDir.delete();
+            }
+            catch (IOException ioe) {
+                Log.e(TAG, "Can't add entry to zip file", ioe);
+                throw new IllegalStateException("Can't add entry to zip file", ioe);
+            }
+        }
+        else {
+            Log.e(TAG, "There's no files in track directory");
+            throw new IllegalStateException("There's no files in track directory");
+        }
+        sharedFiles.put(filename, fileToShare);
+
         Uri tempFileUri = Uri.parse("content://me.guillaumin.android.osmtracker.fileshareprovider/" + filename);
         Intent shareTrack = new Intent(Intent.ACTION_SEND);
         shareTrack.setType("application/xml");
@@ -85,7 +156,7 @@ public class ExportAndShareTask extends ExportTrackTask {
 
         PackageManager packageManager = context.getPackageManager();
         if (packageManager.queryIntentActivities(shareTrack, PackageManager.MATCH_DEFAULT_ONLY).size() > 0)
-            context.startActivity(shareTrack);
+            context.startActivity(Intent.createChooser(shareTrack, context.getResources().getString(R.string.sharetrack_choose_app)));
         else
         {
             AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(context);

--- a/app/src/main/java/me/guillaumin/android/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/me/guillaumin/android/osmtracker/gpx/ExportTrackTask.java
@@ -192,29 +192,27 @@ public abstract class ExportTrackTask  extends AsyncTask<Void, Long, Boolean> {
 	}
 
 	private void exportTrackAsGpx(long trackId) throws ExportTrackException {
-		File sdRoot = Environment.getExternalStorageDirectory();
-		
-		if (sdRoot.canWrite()) {
-			ContentResolver cr = context.getContentResolver();
-			
-			Cursor c = context.getContentResolver().query(ContentUris.withAppendedId(
-					TrackContentProvider.CONTENT_URI_TRACK, trackId), null, null,
-					null, null);
+		ContentResolver cr = context.getContentResolver();
 
-			// Get the startDate of this track
-			// TODO: Maybe we should be pulling the track name instead?
-			// We'd need to consider the possibility that two tracks were given the same name
-			// We could possibly disambiguate by including the track ID in the Folder Name
-			// to avoid overwriting another track on one hand or needlessly creating additional
-			// directories to avoid overwriting.
-			Date startDate = new Date();
-			if (null != c && 1 <= c.getCount()) {
-				c.moveToFirst();
-				long startDateInMilliseconds = c.getLong(c.getColumnIndex(Schema.COL_START_DATE));
-				startDate.setTime(startDateInMilliseconds);
-			}
+		Cursor c = context.getContentResolver().query(ContentUris.withAppendedId(
+				TrackContentProvider.CONTENT_URI_TRACK, trackId), null, null,
+				null, null);
 
-			File trackGPXExportDirectory = getExportDirectory(startDate);
+		// Get the startDate of this track
+		// TODO: Maybe we should be pulling the track name instead?
+		// We'd need to consider the possibility that two tracks were given the same name
+		// We could possibly disambiguate by including the track ID in the Folder Name
+		// to avoid overwriting another track on one hand or needlessly creating additional
+		// directories to avoid overwriting.
+		Date startDate = new Date();
+		if (null != c && 1 <= c.getCount()) {
+			c.moveToFirst();
+			long startDateInMilliseconds = c.getLong(c.getColumnIndex(Schema.COL_START_DATE));
+			startDate.setTime(startDateInMilliseconds);
+		}
+
+		File trackGPXExportDirectory = getExportDirectory(startDate);
+		if (trackGPXExportDirectory.canWrite()) {
 			String filenameBase = buildGPXFilename(c);
 			c.close();
 			

--- a/app/src/main/java/me/guillaumin/android/osmtracker/gpx/TrackFileProvider.java
+++ b/app/src/main/java/me/guillaumin/android/osmtracker/gpx/TrackFileProvider.java
@@ -1,0 +1,121 @@
+package me.guillaumin.android.osmtracker.gpx;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.AbstractCursor;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+/**
+ */
+
+public final class TrackFileProvider extends ContentProvider {
+    private static final String TAG = ExportToTempFileTask.class.getSimpleName();
+
+    @Override
+    public boolean onCreate() {
+        return false;
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        return new AbstractCursor() {
+            @Override
+            public int getCount() {
+                return 0;
+            }
+
+            @Override
+            public String[] getColumnNames() {
+                return new String[0];
+            }
+
+            @Override
+            public String getString(int column) {
+                return null;
+            }
+
+            @Override
+            public short getShort(int column) {
+                return 0;
+            }
+
+            @Override
+            public int getInt(int column) {
+                return 0;
+            }
+
+            @Override
+            public long getLong(int column) {
+                return 0;
+            }
+
+            @Override
+            public float getFloat(int column) {
+                return 0;
+            }
+
+            @Override
+            public double getDouble(int column) {
+                return 0;
+            }
+
+            @Override
+            public boolean isNull(int column) {
+                return false;
+            }
+        };
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        return "application/xml";
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public String[] getStreamTypes(Uri uri, String mimeTypeFilter) {
+        String[] mimeTypes = {"application/xml", "application/gpx", "application/gpx+xml", "application/xml+gpx", "text/xml"};
+        String mimeTypesFiltered = "";
+        for (String mimeType : mimeTypes)
+            if (mimeTypeFilter.contains(mimeType))
+                mimeTypesFiltered += " " + mimeType;
+        return mimeTypesFiltered.split(" ");
+    }
+
+    @Override
+    public ParcelFileDescriptor openFile(Uri uri, String mode)
+    {
+        ParcelFileDescriptor fileDescriptor = null;
+        File sharedFile = ExportAndShareTask.sharedFiles.get(uri.getLastPathSegment());
+        if (sharedFile != null)
+            try {
+                fileDescriptor = ParcelFileDescriptor.open(sharedFile, ParcelFileDescriptor.MODE_READ_ONLY);
+            }
+            catch (FileNotFoundException exception) {
+                Log.e(TAG, "Could not find temporary file", exception);
+            }
+        else
+            Log.e(TAG, "Requested file is not shared");
+        return fileDescriptor;
+    }
+}

--- a/app/src/main/res/menu/trackdetail_menu.xml
+++ b/app/src/main/res/menu/trackdetail_menu.xml
@@ -27,6 +27,7 @@
     <item
         android:id="@+id/trackdetail_menu_share"
         android:icon="@android:drawable/ic_menu_share"
+        android:showAsAction="ifRoom|withText"
         android:title="@string/menu_share"></item>
     <item
         android:id="@+id/trackdetail_menu_osm_upload"

--- a/app/src/main/res/menu/trackdetail_menu.xml
+++ b/app/src/main/res/menu/trackdetail_menu.xml
@@ -25,6 +25,10 @@
         android:showAsAction="ifRoom|withText">
     </item>
     <item
+        android:id="@+id/trackdetail_menu_share"
+        android:icon="@android:drawable/ic_menu_share"
+        android:title="@string/menu_share"></item>
+    <item
         android:id="@+id/trackdetail_menu_osm_upload"
         android:icon="@android:drawable/ic_menu_upload"
         android:title="@string/menu_osm_upload">

--- a/app/src/main/res/menu/trackmgr_contextmenu.xml
+++ b/app/src/main/res/menu/trackmgr_contextmenu.xml
@@ -6,6 +6,7 @@
 <item android:id="@+id/trackmgr_contextmenu_display" android:title="@string/trackmgr_contextmenu_display"></item>
 <item android:id="@+id/trackmgr_contextmenu_details" android:title="@string/trackmgr_contextmenu_details"></item>
 <item android:id="@+id/trackmgr_contextmenu_export" android:title="@string/trackmgr_contextmenu_export"></item>
+<item android:id="@+id/trackmgr_contextmenu_share" android:title="@string/trackmgr_contextmenu_share"></item>
 <item android:id="@+id/trackmgr_contextmenu_osm_upload" android:title="@string/trackmgr_contextmenu_osm_upload"></item>
 <item android:id="@+id/trackmgr_contextmenu_delete" android:title="@string/trackmgr_contextmenu_delete" ></item>
 </menu>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -92,6 +92,7 @@
   <string name="menu_save">Сохранить</string>
   <string name="menu_cancel">Отмена</string>
   <string name="menu_export">Экспортировать в GPX</string>
+  <string name="menu_share">Передать как GPX</string>
   <string name="menu_osm_upload">Загрузка на OpenStreetMap</string>
   <string name="menu_center_to_gps">Центрировать по GPS</string>
   <string name="menu_exportall">Экспорт всех в GPX</string>
@@ -100,7 +101,8 @@
   <string name="error_create_track_dir">Невозможно создать папку трека %s.</string>
   <string name="error_externalstorage_not_writable_hint">Проверьте, что флеш карта правильно вставлена и примонтирована.</string>
   <string name="error_voicerec_failed">Ошибка записи аудио</string>
-  <string name="error_userlayout_parsing">Ошибка при загрузки файла расположения кнопок. Вернитесь к файлу по умолчанию.</string>
+  <string name="error_userlayout_parsing">Ошибка при загрузке файла расположения кнопок. Вернитесь к файлу по умолчанию.</string>
+  <string name="error_no_appropriate_activity">Приложение, способное принять gpx-файл, не найдено.</string>
   <!--GPX-->
   <string name="gpx_track_name">Записано на OSMTracker for Android™</string>
   <string name="gpx_hdop_approximation_cmt">Внимание: значения записываемые в файл как HDOP — это не значения HDOP, получаемые от GPS устройства. Это приближённо вычисленное значение, полученное из метровой точности местоположения.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -36,6 +36,7 @@
   <string name="trackmgr_contextmenu_resume">Продолжить запись</string>
   <string name="trackmgr_contextmenu_delete">Удалить</string>
   <string name="trackmgr_contextmenu_export">Экспортировать в GPX</string>
+  <string name="trackmgr_contextmenu_share">Поделиться</string>
   <string name="trackmgr_contextmenu_osm_upload">Загрузить на OpenStreetMap</string>
   <string name="trackmgr_contextmenu_display">Показать</string>
   <string name="trackmgr_contextmenu_details">Подробности</string>
@@ -93,7 +94,7 @@
   <string name="menu_save">Сохранить</string>
   <string name="menu_cancel">Отмена</string>
   <string name="menu_export">Экспортировать в GPX</string>
-  <string name="menu_share">Передать как GPX</string>
+  <string name="menu_share">Поделиться</string>
   <string name="menu_osm_upload">Загрузка на OpenStreetMap</string>
   <string name="menu_center_to_gps">Центрировать по GPS</string>
   <string name="menu_exportall">Экспорт всех в GPX</string>
@@ -103,7 +104,7 @@
   <string name="error_externalstorage_not_writable_hint">Проверьте, что флеш карта правильно вставлена и примонтирована.</string>
   <string name="error_voicerec_failed">Ошибка записи аудио</string>
   <string name="error_userlayout_parsing">Ошибка при загрузке файла расположения кнопок. Вернитесь к файлу по умолчанию.</string>
-  <string name="error_no_appropriate_activity">Приложение, способное принять gpx-файл, не найдено.</string>
+  <string name="error_no_appropriate_activity">Приложение, способное принимать %s-файлы, не найдено.</string>
   <!--GPX-->
   <string name="gpx_track_name">Записано на OSMTracker for Android™</string>
   <string name="gpx_hdop_approximation_cmt">Внимание: значения записываемые в файл как HDOP — это не значения HDOP, получаемые от GPS устройства. Это приближённо вычисленное значение, полученное из метровой точности местоположения.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -64,6 +64,7 @@
   <string name="osm_visibility_public">Общедоступный</string>
   <string name="osm_visibility_trackable">Отслеживаемый</string>
   <string name="osm_visibility_identifiable">Идентифицируемый</string>
+  <string name="sharetrack_choose_app">Выберите с помощью какого приложения передать трек</string>
   <!--OSM upload-->
   <string name="osm_upload">Загрузка на OpenStreetMap</string>
   <string name="osm_upload_ok">Сохранить и загрузить</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
 	<string name="trackmgr_contextmenu_resume">Resume tracking</string>
 	<string name="trackmgr_contextmenu_delete">Delete</string>
 	<string name="trackmgr_contextmenu_export">Export as GPX</string>
+	<string name="trackmgr_contextmenu_share">Share</string>
 	<string name="trackmgr_contextmenu_osm_upload">Upload to OpenStreetMap</string>
 	<string name="trackmgr_contextmenu_display">Display</string>
 	<string name="trackmgr_contextmenu_details">Details</string>
@@ -71,7 +72,7 @@
 	<string name="osm_visibility_public">Public</string>
 	<string name="osm_visibility_trackable">Trackable</string>
 	<string name="osm_visibility_identifiable">Identifiable</string>
-	<string name="sharetrack_choose_app">Choose an application to share the track</string>
+	<string name="sharetrack_choose_app">Choose an application to share the track with</string>
 
 	<!-- OSM upload -->
 	<string name="osm_upload">OpenStreetMap upload</string>
@@ -103,7 +104,7 @@
 	<string name="menu_save">Save</string>
 	<string name="menu_cancel">Cancel</string>
 	<string name="menu_export">Export as GPX</string>
-    <string name="menu_share">Share as GPX</string>
+	<string name="menu_share">Share</string>
 	<string name="menu_osm_upload">OpenStreetMap upload</string>
 	<string name="menu_center_to_gps">Center to GPS</string>
 	<string name="menu_exportall">Export all as GPX</string>
@@ -114,7 +115,7 @@
 	<string name="error_externalstorage_not_writable_hint">Please check if ext. storage is correctly inserted and mounted.</string>
 	<string name="error_voicerec_failed">Voice recording has failed</string>
 	<string name="error_userlayout_parsing">Error while parsing XML layout file. Please revert to default layout.</string>
-	<string name="error_no_appropriate_activity">No application able to handle gpx file was found.</string>
+	<string name="error_no_appropriate_activity">No application able to handle %s files was found.</string>
 
 	<!-- GPX -->
 	<string name="gpx_track_name">Tracked with OSMTracker for Android™</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
 	<string name="menu_save">Save</string>
 	<string name="menu_cancel">Cancel</string>
 	<string name="menu_export">Export as GPX</string>
+    <string name="menu_share">Share as GPX</string>
 	<string name="menu_osm_upload">OpenStreetMap upload</string>
 	<string name="menu_center_to_gps">Center to GPS</string>
 	<string name="menu_exportall">Export all as GPX</string>
@@ -112,6 +113,7 @@
 	<string name="error_externalstorage_not_writable_hint">Please check if ext. storage is correctly inserted and mounted.</string>
 	<string name="error_voicerec_failed">Voice recording has failed</string>
 	<string name="error_userlayout_parsing">Error while parsing XML layout file. Please revert to default layout.</string>
+	<string name="error_no_appropriate_activity">No application able to handle gpx file was found.</string>
 
 	<!-- GPX -->
 	<string name="gpx_track_name">Tracked with OSMTracker for Android™</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,6 +71,7 @@
 	<string name="osm_visibility_public">Public</string>
 	<string name="osm_visibility_trackable">Trackable</string>
 	<string name="osm_visibility_identifiable">Identifiable</string>
+	<string name="sharetrack_choose_app">Choose an application to share the track</string>
 
 	<!-- OSM upload -->
 	<string name="osm_upload">OpenStreetMap upload</string>


### PR DESCRIPTION
It solves #69, #84 and a little bit of #85. It exports the track with media to cache dir (if there's more then 1 file, the files are packed into zip archive) and shares it with other apps via ContentProvider. Checked it on my device with standard email app, Gmail and DropBox.
Also I've slightly changed logic of writability check when exporting track: now it checks writability of target dir instead of writability of external storage (since we do not need writable external storage when saving temporary file)