### PR TITLE
fix IllegalArgumentException from dismiss

### DIFF
--- a/app/src/main/java/org/osmtracker/activity/TrackDetail.java
+++ b/app/src/main/java/org/osmtracker/activity/TrackDetail.java
@@ -70,7 +70,8 @@ public class TrackDetail extends TrackDetailEditor implements AdapterView.OnItem
 	 * List with track info
 	 */
 	private ListView lv;
-	
+	private ExportToStorageTask exportToStorageTask;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState, R.layout.trackdetail, getIntent().getExtras().getLong(TrackContentProvider.Schema.COL_TRACK_ID));
@@ -197,6 +198,13 @@ public class TrackDetail extends TrackDetailEditor implements AdapterView.OnItem
 		// Click on Waypoint count to see the track's WaypointList
 		lv.setOnItemClickListener(this);
 	}
+	@Override
+	public void onPause() {
+		super.onPause();
+		if(exportToStorageTask != null) {
+			exportToStorageTask.parentNotVisible();
+		}
+	}
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu) {
@@ -230,7 +238,8 @@ public class TrackDetail extends TrackDetailEditor implements AdapterView.OnItem
 			startActivity(i);	
 			break;
 		case R.id.trackdetail_menu_export:
-			new ExportToStorageTask(this, trackId).execute();
+			exportToStorageTask = new ExportToStorageTask(this, trackId);
+			exportToStorageTask.execute();
 			// Pick last list item (Exported date) and update it
 			SimpleAdapter adapter = ((SimpleAdapter) lv.getAdapter());
 			@SuppressWarnings("unchecked")

--- a/app/src/main/java/org/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/org/osmtracker/activity/TrackManager.java
@@ -57,6 +57,7 @@ public class TrackManager extends ListActivity {
 
 	/** The previous item visible, or -1; for scrolling back to its position in {@link #onResume()} */
 	private int prevItemVisible = -1;
+	private ExportToStorageTask exportToStorageTask;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -116,6 +117,9 @@ public class TrackManager extends ListActivity {
 
 	@Override
 	protected void onPause() {
+		if(exportToStorageTask!= null) {
+			exportToStorageTask.parentNotVisible();
+		}
 		// Remember position in listview (before any adapter change)
 		prevItemVisible = getListView().getFirstVisiblePosition();
 
@@ -242,7 +246,8 @@ public class TrackManager extends ListActivity {
 								ids[i++] = cursor.getLong(idCol);
 							} while (cursor.moveToNext());
 							
-							new ExportToStorageTask(TrackManager.this, ids).execute();
+							exportToStorageTask = new ExportToStorageTask(TrackManager.this, ids);
+							exportToStorageTask.execute();
 						}
 						cursor.close();
 					}
@@ -328,8 +333,9 @@ public class TrackManager extends ListActivity {
 				}).create().show();
 
 			break;
-		case R.id.trackmgr_contextmenu_export:	
-			new ExportToStorageTask(this, info.id).execute();
+		case R.id.trackmgr_contextmenu_export:
+			exportToStorageTask = new ExportToStorageTask(this, info.id);
+			exportToStorageTask.execute();
 			break;
 		case R.id.trackmgr_contextmenu_osm_upload:
 			i = new Intent(this, OpenStreetMapUpload.class);

--- a/app/src/main/java/org/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/org/osmtracker/gpx/ExportTrackTask.java
@@ -143,7 +143,11 @@ public abstract class ExportTrackTask  extends AsyncTask<Void, Long, Boolean> {
 		}
 		return true;
 	}
-	
+	public void parentNotVisible(){
+		if(getStatus() == Status.FINISHED || getStatus() == Status.RUNNING) {
+			dialog.dismiss();
+		}
+	}
 	@Override
 	protected void onProgressUpdate(Long... values) {
 		if (values.length == 1) {
@@ -152,7 +156,9 @@ public abstract class ExportTrackTask  extends AsyncTask<Void, Long, Boolean> {
 		} else if (values.length == 3) {
 			// To initialise the dialog, 3 values are passed to onProgressUpdate()
 			// trackId, number of track points, number of waypoints
-			dialog.dismiss();
+			if(dialog.isShowing()) {
+				dialog.dismiss();
+			}
 			
 			dialog = new ProgressDialog(context);
 			dialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
@@ -170,7 +176,9 @@ public abstract class ExportTrackTask  extends AsyncTask<Void, Long, Boolean> {
 
 	@Override
 	protected void onPostExecute(Boolean success) {
-		dialog.dismiss();
+		if(dialog.isShowing()) {
+			dialog.dismiss();
+		}
 		if (!success) {
 			new AlertDialog.Builder(context)
 				.setTitle(android.R.string.dialog_alert_title)
@@ -181,7 +189,9 @@ public abstract class ExportTrackTask  extends AsyncTask<Void, Long, Boolean> {
 				.setNeutralButton(android.R.string.ok, new OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int which) {
-						dialog.dismiss();						
+						if(((AlertDialog)dialog).isShowing()){
+							dialog.dismiss();
+						}
 					}
 				})
 				.show();

--- a/app/src/main/java/org/osmtracker/osm/UploadToOpenStreetMapTask.java
+++ b/app/src/main/java/org/osmtracker/osm/UploadToOpenStreetMapTask.java
@@ -159,14 +159,18 @@ public class UploadToOpenStreetMapTask extends AsyncTask<Void, Void, Void> {
 	protected void onPostExecute(Void result) {
 		switch (resultCode) {
 		case -1:
-			dialog.dismiss();
+			if(dialog.isShowing()) {
+				dialog.dismiss();
+			}
 			// Internal error, the request didn't start at all
 			DialogUtils.showErrorDialog(activity,
 					activity.getResources().getString(R.string.osm_upload_error)
 						+ ": " + errorMsg);
 			break;
 		case HttpStatus.SC_OK:
-			dialog.dismiss();
+			if(dialog.isShowing()) {
+				dialog.dismiss();
+			}
 			// Success ! Update database and close activity
 			DataHelper.setTrackUploadDate(trackId, System.currentTimeMillis(), activity.getContentResolver());
 			
@@ -185,7 +189,9 @@ public class UploadToOpenStreetMapTask extends AsyncTask<Void, Void, Void> {
 			
 			break;
 		case HttpStatus.SC_UNAUTHORIZED:
-			dialog.dismiss();
+			if(dialog.isShowing()) {
+				dialog.dismiss();
+			}
 			// Authorization issue. Provide a way to clear credentials
 			new AlertDialog.Builder(activity)
 					.setTitle(android.R.string.dialog_alert_title)
@@ -195,7 +201,9 @@ public class UploadToOpenStreetMapTask extends AsyncTask<Void, Void, Void> {
 					.setNegativeButton(android.R.string.no, new DialogInterface.OnClickListener() {
 						@Override
 						public void onClick(DialogInterface dialog, int which) {
-							dialog.dismiss();								
+							if(((AlertDialog)dialog).isShowing()) {
+								dialog.dismiss();
+							}
 						}
 					})
 					.setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
@@ -205,8 +213,9 @@ public class UploadToOpenStreetMapTask extends AsyncTask<Void, Void, Void> {
 							editor.remove(OSMTracker.Preferences.KEY_OSM_OAUTH_TOKEN);
 							editor.remove(OSMTracker.Preferences.KEY_OSM_OAUTH_SECRET);
 							editor.commit();
-
-							dialog.dismiss();
+							if(((AlertDialog)dialog).isShowing()) {
+								dialog.dismiss();
+							}
 						}
 					}).create().show();
 
@@ -220,8 +229,9 @@ public class UploadToOpenStreetMapTask extends AsyncTask<Void, Void, Void> {
 				while ( (line = reader.readLine()) != null) {
 					sb.append(line).append(System.getProperty("line.separator"));
 				}
-				
-				dialog.dismiss();
+				if(dialog.isShowing()) {
+					dialog.dismiss();
+				}
 				
 				DialogUtils.showErrorDialog(activity,
 						activity.getResources().getString(R.string.osm_upload_bad_response)
@@ -255,5 +265,10 @@ public class UploadToOpenStreetMapTask extends AsyncTask<Void, Void, Void> {
 		}
 		
 		return null;
+	}
+	public void parentNotVisible(){
+		if(getStatus() == Status.FINISHED || getStatus() == Status.RUNNING) {
+			dialog.dismiss();
+		}
 	}
 }


### PR DESCRIPTION
Hi I am with the University of Colorado programming languages and verification group.  We are working on methods to automatically detect hard to find defects in Android applications. I recently found this one with the tools I am developing for my research and attempted to fix it to the best of my abilities.

To reproduce:
--------------
* You should be able to use any device, however I tested on the emulator and my Samsung galaxy s7
* Create a track
* Export or upload track and quickly rotate phone
* Application will crash with an IllegalArgumentException if the timing right
* To make the crash easier to observe in testing, delay the doInBackground method of ExportTrackTask by half a second, however this is not necessary as a slow SD card or network connection could cause this.
```
        @Override
        protected Boolean doInBackground(Void... params) {
                try {
                        Thread.sleep(500);
                } catch (InterruptedException e) {
                        e.printStackTrace();
                }
```

ADB logcat / stacktrace
---------------
```
E/AndroidRuntime: FATAL EXCEPTION: main
                  Process: org.osmtracker, PID: 4182
                  java.lang.IllegalArgumentException: View=DecorView@5bd7f9f[] not attached to window manager
                      at android.view.WindowManagerGlobal.findViewLocked(WindowManagerGlobal.java:473)
                      at android.view.WindowManagerGlobal.removeView(WindowManagerGlobal.java:382)
                      at android.view.WindowManagerImpl.removeViewImmediate(WindowManagerImpl.java:124)
                      at android.app.Dialog.dismissDialog(Dialog.java:357)
                      at android.app.Dialog.dismiss(Dialog.java:340)
                      at org.osmtracker.gpx.ExportTrackTask.onProgressUpdate(ExportTrackTask.java:160)
                      at org.osmtracker.gpx.ExportTrackTask.onProgressUpdate(ExportTrackTask.java:42)
                      at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:680)
                      at android.os.Handler.dispatchMessage(Handler.java:102)
                      at android.os.Looper.loop(Looper.java:154)
                      at android.app.ActivityThread.main(ActivityThread.java:6077)
                      at java.lang.reflect.Method.invoke(Native Method)
                      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)
                      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)
```

Explanation
------------

The ```dismiss()``` method on ```ProgressDialog`` cannot be called after the associated ```Activity``` object has been paused.  Since there are dismiss methods in the ```doInBackground()``` and ```onPostExecute()``` callbacks it is possible for these to be invoked after the activity has paused but before it has resumed.


Fix
---
To fix this I dismiss the dialog when the activity is paused and then check if it is showing before dismiss is invoked.  Unfortunately the ```isShowing()``` method will return true after the dialog has been hidden through a rotation so the ```dismiss()``` in the ```onPause()``` callback is necessary.

I hope this helps!  Great application by the way.