### PR TITLE
Fix when upload GPX data to OSM (error 500)

### DIFF
--- a/app/src/main/java/org/osmtracker/osm/OpenStreetMapConstants.java
+++ b/app/src/main/java/org/osmtracker/osm/OpenStreetMapConstants.java
@@ -4,8 +4,8 @@ public class OpenStreetMapConstants {
 
 	private static final boolean DEV_MODE = false;
 	
-	private static final String OSM_API_URL_DEV = "http://master.apis.dev.openstreetmap.org";
-	private static final String OSM_API_URL_PROD = "http://www.openstreetmap.org";
+	private static final String OSM_API_URL_DEV = "https://master.apis.dev.openstreetmap.org";
+	private static final String OSM_API_URL_PROD = "https://www.openstreetmap.org";
 	private static final String OSM_API_URL = (DEV_MODE) ? OSM_API_URL_DEV : OSM_API_URL_PROD;
 	
 	public static class Api {


### PR DESCRIPTION
This PR intend to fix the error mentioned in issue #137:

This error appears in **OpenStreetMapConstants** class

Line with error:  
 
```Java
private static final String OSM_API_URL_DEV = "http://master.apis.dev.openstreetmap.org";  
private static final String OSM_API_URL_PROD = "http://www.openstreetmap.org";
```

The solution is to change from `http` to `https` in both lines:  

```Java
private static final String OSM_API_URL_DEV = "https://master.apis.dev.openstreetmap.org";  
private static final String OSM_API_URL_PROD = "https://www.openstreetmap.org";
```