### PR TITLE
Fix travis build failing because of missing license agreement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ android:
         - android-16
         - android-19
         - sys-img-armeabi-v7a-android-19
+before_install:
+- yes | sdkmanager "platforms;android-27"
 
 before_script:
      - echo no | android create avd --force -n test -c 100M -t android-19 --abi armeabi-v7a


### PR DESCRIPTION
But it fails anyway at an other point:

```
net.osmtracker.test.gpx.ExportTrackTaskTest > test[test(AVD) - 4.4.2] FAILED 
	junit.framework.AssertionFailedError
	at net.osmtracker.test.gpx.ExportTrackTaskTest.test(ExportTrackTaskTest.java:76)
:app:connectedDebugAndroidTest FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':app:connectedDebugAndroidTest'.
> There were failing tests. See the report at: file:///home/travis/build/dadosch/osmtracker-android/app/build/reports/androidTests/connected/index.html
```