### PR TITLE
Motion detection/minimum distance between subsequent track points 

### DIFF
--- a/app/src/main/java/net/osmtracker/OSMTracker.java
+++ b/app/src/main/java/net/osmtracker/OSMTracker.java
@@ -22,6 +22,7 @@ public class OSMTracker {
 		public final static String KEY_GPS_CHECKSTARTUP = "gps.checkstartup";
 		public final static String KEY_GPS_IGNORE_CLOCK = "gps.ignoreclock";
 		public final static String KEY_GPS_LOGGING_INTERVAL = "gps.logging.interval";
+		public final static String KEY_GPS_LOGGING_MIN_DISTANCE = "gps.logging.min_distance";
 		public final static String KEY_OUTPUT_FILENAME = "gpx.filename";
 		public final static String KEY_OUTPUT_ACCURACY = "gpx.accuracy";
 		public final static String KEY_OUTPUT_GPX_HDOP_APPROXIMATION = "gpx.hdop.approximation";
@@ -53,6 +54,7 @@ public class OSMTracker {
 		public final static boolean VAL_GPS_CHECKSTARTUP = true;
 		public final static boolean VAL_GPS_IGNORE_CLOCK = false;
 		public final static String VAL_GPS_LOGGING_INTERVAL = "0";
+		public final static String VAL_GPS_LOGGING_MIN_DISTANCE = "0";
 		
 		public final static String VAL_OUTPUT_FILENAME_NAME = "name";
 		public final static String VAL_OUTPUT_FILENAME_NAME_DATE = "name_date";

--- a/app/src/main/java/net/osmtracker/activity/Preferences.java
+++ b/app/src/main/java/net/osmtracker/activity/Preferences.java
@@ -7,6 +7,7 @@ import net.osmtracker.OSMTracker;
 import net.osmtracker.R;
 
 import android.Manifest;
+import android.app.AlertDialog;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
@@ -22,6 +23,10 @@ import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.widget.Button;
+import android.widget.EditText;
 
 
 /**
@@ -126,6 +131,36 @@ public class Preferences extends PreferenceActivity {
 				return true;
 			}
 		});
+
+		// don't allow the logging_min_distance to be empty
+		final EditText et = ((EditTextPreference)pref).getEditText();
+		final EditTextPreference etp = (EditTextPreference)pref;
+		et.addTextChangedListener(
+				new TextWatcher() {
+					@Override
+					public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+					}
+
+					@Override
+					public void onTextChanged(CharSequence s, int start, int before, int count) {
+						if (s.length() >= 0) {
+							try {
+								Button bt_ok = ((AlertDialog) etp.getDialog()).getButton(AlertDialog.BUTTON_POSITIVE);
+								if (s.length() == 0) {
+									bt_ok.setEnabled(false);
+								} else {
+									((AlertDialog) etp.getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
+								}
+							} catch (Exception ex) {
+							}
+						}
+					}
+
+					@Override
+					public void afterTextChanged(Editable s) {
+					}
+				}
+		);
 
 		pref = findPreference(OSMTracker.Preferences.KEY_GPS_OSSETTINGS);
 		pref.setOnPreferenceClickListener(new OnPreferenceClickListener() {

--- a/app/src/main/java/net/osmtracker/activity/Preferences.java
+++ b/app/src/main/java/net/osmtracker/activity/Preferences.java
@@ -110,6 +110,23 @@ public class Preferences extends PreferenceActivity {
 			}
 		});
 
+		// Update GPS min. distance summary to the current value
+		pref = findPreference(OSMTracker.Preferences.KEY_GPS_LOGGING_MIN_DISTANCE);
+		pref.setSummary(
+				prefs.getString(OSMTracker.Preferences.KEY_GPS_LOGGING_MIN_DISTANCE, OSMTracker.Preferences.VAL_GPS_LOGGING_MIN_DISTANCE)
+						+ " " + getResources().getString(R.string.prefs_gps_logging_min_distance_meters)
+						+ ". " + getResources().getString(R.string.prefs_gps_logging_min_distance_summary));
+		pref.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+			@Override
+			public boolean onPreferenceChange(Preference preference, Object newValue) {
+				// Set summary with the interval and "seconds"
+				preference.setSummary(newValue
+						+ " " + getResources().getString(R.string.prefs_gps_logging_min_distance_meters)
+						+ ". " + getResources().getString(R.string.prefs_gps_logging_min_distance_summary));
+				return true;
+			}
+		});
+
 		pref = findPreference(OSMTracker.Preferences.KEY_GPS_OSSETTINGS);
 		pref.setOnPreferenceClickListener(new OnPreferenceClickListener() {
 			@Override

--- a/app/src/main/java/net/osmtracker/service/gps/GPSLogger.java
+++ b/app/src/main/java/net/osmtracker/service/gps/GPSLogger.java
@@ -90,6 +90,7 @@ public class GPSLogger extends Service implements LocationListener {
 	 * the interval (in ms) to log GPS fixes defined in the preferences
 	 */
 	private long gpsLoggingInterval;
+	private long gpsLoggingMinDistance;
 	
 	/**
 	 * sensors for magnetic orientation
@@ -200,6 +201,8 @@ public class GPSLogger extends Service implements LocationListener {
 		//read the logging interval from preferences
 		gpsLoggingInterval = Long.parseLong(PreferenceManager.getDefaultSharedPreferences(this.getApplicationContext()).getString(
 				OSMTracker.Preferences.KEY_GPS_LOGGING_INTERVAL, OSMTracker.Preferences.VAL_GPS_LOGGING_INTERVAL)) * 1000;
+		gpsLoggingMinDistance = Long.parseLong(PreferenceManager.getDefaultSharedPreferences(this.getApplicationContext()).getString(
+				OSMTracker.Preferences.KEY_GPS_LOGGING_MIN_DISTANCE, OSMTracker.Preferences.VAL_GPS_LOGGING_MIN_DISTANCE));
 		
 		// Register our broadcast receiver
 		IntentFilter filter = new IntentFilter();
@@ -214,8 +217,8 @@ public class GPSLogger extends Service implements LocationListener {
 		lmgr = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
 
 		if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED) {
-            lmgr.requestLocationUpdates(LocationManager.GPS_PROVIDER, 0, 0, this);
-        }
+			lmgr.requestLocationUpdates(LocationManager.GPS_PROVIDER, gpsLoggingInterval, gpsLoggingMinDistance, this);
+		}
 		
 		//register for Orientation updates
 		sensorListener.register(this);

--- a/app/src/main/res/values-de/strings-preferences.xml
+++ b/app/src/main/res/values-de/strings-preferences.xml
@@ -12,6 +12,10 @@
   <string name="prefs_gps_logging_interval">GPS Intervall</string>
   <string name="prefs_gps_logging_interval_summary">0 für das kürzest mögliche Intervall</string>
   <string name="prefs_gps_logging_interval_seconds">Sekunden</string>
+  <string name="prefs_gps_logging_min_distance">GPS Distanz Trackpoints</string>
+  <string name="prefs_gps_logging_min_distance_summary">Min. Abstand zweier Trackpoints</string>
+  <string name="prefs_gps_logging_min_distance_meters">Meter</string>
+
   <string name="prefs_ui">Benutzeroberfläche</string>
   <string name="prefs_ui_picture_source">Standard Foto-Quelle</string>
   <string name="prefs_ui_picture_source_summary">Foto von Kamera oder Galerie?</string>

--- a/app/src/main/res/values/strings-preferences.xml
+++ b/app/src/main/res/values/strings-preferences.xml
@@ -19,6 +19,10 @@
 	<string name="prefs_gps_logging_interval_summary">Use 0 for the shortest possible (affects battery life)</string>
 	<string name="prefs_gps_logging_interval_seconds">seconds</string>
 
+	<string name="prefs_gps_logging_min_distance">GPS logging distance</string>
+	<string name="prefs_gps_logging_min_distance_summary">Min. distance between track points in meters, use 0 for the shortest possible</string>
+	<string name="prefs_gps_logging_min_distance_meters">meters</string>
+
 	<string name="prefs_ui">User interface</string>
 	
 	<string name="prefs_ui_picture_source">Default photo source</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -21,6 +21,9 @@
 		<EditTextPreference android:key="gps.logging.interval"
 			android:title="@string/prefs_gps_logging_interval" android:summary="@string/prefs_gps_logging_interval_summary"
 			android:defaultValue="0" android:inputType="number"></EditTextPreference>
+		<EditTextPreference android:key="gps.logging.min_distance"
+			android:title="@string/prefs_gps_logging_min_distance" android:summary="@string/prefs_gps_logging_min_distance_summary"
+			android:defaultValue="0" android:inputType="number"></EditTextPreference>
 	</PreferenceCategory>
 	
 	<PreferenceCategory android:title="@string/prefs_output">


### PR DESCRIPTION
I found it would be useful to have kind of a "motion detection" to avoid polluting the track with redundant points while the user is standing still. The PR implements this in a most simple way by using Android LocationManager.requestLocationUpdates's parameter "minDistance". A new preference has been introduced to set the threshold (value in meters):
Settings -> GPS logging distance

(PR was initially against master branch)