### PR TITLE
Fix issue 183

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/ButtonsPresets.java
+++ b/app/src/main/java/net/osmtracker/activity/ButtonsPresets.java
@@ -104,8 +104,7 @@ public class ButtonsPresets extends Activity {
         listener = new CheckBoxChangedListener();
         prefs = PreferenceManager.getDefaultSharedPreferences(this);
         layoutsFileNames = new Hashtable<String, String>();
-        storageDir = File.separator + prefs.getString(OSMTracker.Preferences.KEY_STORAGE_DIR,
-                                                 OSMTracker.Preferences.VAL_STORAGE_DIR);
+        storageDir = File.separator + OSMTracker.Preferences.VAL_STORAGE_DIR;
     }
 
     private void listLayouts(LinearLayout rootLayout){

--- a/app/src/main/java/net/osmtracker/activity/TrackLogger.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackLogger.java
@@ -279,8 +279,7 @@ public class TrackLogger extends Activity {
 		
 		// Try to inflate the buttons layout
 		try {
-			String userLayout = prefs.getString(
-					OSMTracker.Preferences.KEY_UI_BUTTONS_LAYOUT, OSMTracker.Preferences.VAL_UI_BUTTONS_LAYOUT);
+			String userLayout = prefs.getString(OSMTracker.Preferences.KEY_UI_BUTTONS_LAYOUT, OSMTracker.Preferences.VAL_UI_BUTTONS_LAYOUT);
 			if (OSMTracker.Preferences.VAL_UI_BUTTONS_LAYOUT.equals(userLayout)) {
 				// Using default buttons layout
 				mainLayout = new UserDefinedLayout(this, currentTrackId, null);
@@ -288,9 +287,7 @@ public class TrackLogger extends Activity {
 				// Using user buttons layout
 				File layoutFile = new File(
 						Environment.getExternalStorageDirectory(),
-						prefs.getString(
-								OSMTracker.Preferences.KEY_STORAGE_DIR,
-								OSMTracker.Preferences.VAL_STORAGE_DIR)
+						OSMTracker.Preferences.VAL_STORAGE_DIR
 						+ File.separator + Preferences.LAYOUTS_SUBDIR
 						+ File.separator + userLayout);
 				mainLayout = new UserDefinedLayout(this, currentTrackId, layoutFile);

--- a/app/src/main/java/net/osmtracker/layout/DownloadCustomLayoutTask.java
+++ b/app/src/main/java/net/osmtracker/layout/DownloadCustomLayoutTask.java
@@ -44,7 +44,7 @@ public class DownloadCustomLayoutTask extends AsyncTask<String, Integer, Boolean
         String layoutFolderName = layoutName.replace(" ", "_");
         String iso = layoutData[1];
         SharedPreferences prefs =  PreferenceManager.getDefaultSharedPreferences(context);
-        String storageDir =prefs.getString(OSMTracker.Preferences.KEY_STORAGE_DIR, OSMTracker.Preferences.VAL_STORAGE_DIR);
+        String storageDir = File.separator + OSMTracker.Preferences.VAL_STORAGE_DIR;
 
         String layoutURL = URLCreator.createLayoutFileURL(context, layoutFolderName, iso);
         String layoutPath = Environment.getExternalStorageDirectory() + storageDir + File.separator +


### PR DESCRIPTION
This PR try to solve the issue #183. I changed/separated the path where the layouts and the gpx files are stored (always keeping the default path to both but when it's changed in the settings screen, more specific, under **GPX settings** section, only the Custom Layouts files keep this path).

**Notice**: the default path is */osmtracker* (either in the internal or external storage).
