### PR TITLE
Fix travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,22 @@ jdk: oraclejdk8
 
 android:
     components:
+        - build-tools-28.0.3
+        - android-28
         - tools
-        - platform-tools
-        - tools
-        - build-tools-27.0.3
-        - android-16
-        - android-19
-        - sys-img-armeabi-v7a-android-19
+        - android-21
+        - sys-img-armeabi-v7a-android-21
+
+licenses:
+    - android-sdk-license-.+
+    - '.+'
+
+before_install:
+- mkdir "$ANDROID_HOME/licenses" || true
+- yes | sdkmanager "platforms;android-27"
 
 before_script:
-     - echo no | android create avd --force -n test -c 100M -t android-19 --abi armeabi-v7a
+     - echo no | android create avd --force -n test -c 100M -t android-21 --abi armeabi-v7a
      - emulator -avd test -no-audio -no-window &
      - android-wait-for-emulator
      - adb shell input keyevent 82 &

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 
 language: android
 jdk: oraclejdk8

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,11 @@ android {
             abortOnError false
         }
     }
+
+    defaultConfig {
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+
 }
 
 dependencies {
@@ -60,6 +65,14 @@ dependencies {
     implementation 'oauth.signpost:signpost-commonshttp4:1.2.1.2'
     implementation 'org.slf4j:slf4j-android:1.7.25'
     implementation "com.android.support:support-compat:27.1.1"
+
+    // Required for local unit tests (JUnit 4 framework)
+    testImplementation 'junit:junit:4.12'
+
+    // Required for instrumented tests
+    androidTestImplementation "com.android.support.test:runner:1.0.0"
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:3.0.0"
+
 }
 
 task copyNorwegianValues(type: Copy) {

--- a/app/src/androidTest/assets/gpx/gpx-test.gpx
+++ b/app/src/androidTest/assets/gpx/gpx-test.gpx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/nguillaumin/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/labexp/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
 	<wpt lat="34.12" lon="18.45">
 		<ele>5812.2</ele>
 		<time>2012-03-12T16:46:38Z</time>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,4 +4,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
-distributionSha256Sum=6ac2f8f9302f50241bf14cc5f4a3d88504ad20e61bb98c5fd048f7723b61397e
+distributionSha256Sum=9af7345c199f1731c187c96d3fe3d31f5405192a42046bafa71d846c3d9adacb


### PR DESCRIPTION
This PR includes:

 * ExportTrackTaskTest fixed on Android API 21+. (lower versions of the API aren't supported because the testInstrumentationRunner is not available).

* Gradle 4.6-all checksum was updated

 * Travis was set to run on android 21, using tools 28.0.3. 