### PR TITLE
fix display of background maps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,8 @@
 	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-			
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
 	<application android:label="@string/app_name" android:description="@string/app_description" android:icon="@drawable/ic_launcher" android:theme="@style/HighContrast">
 
 		<activity android:name="net.osmtracker.activity.TrackManager" android:label="@string/app_name">

--- a/app/src/main/java/net/osmtracker/activity/DisplayTrack.java
+++ b/app/src/main/java/net/osmtracker/activity/DisplayTrack.java
@@ -5,13 +5,18 @@ import net.osmtracker.util.ThemeValidator;
 import net.osmtracker.view.DisplayTrackView;
 import net.osmtracker.db.TrackContentProvider;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.view.ViewGroup.LayoutParams;
 
 /**

--- a/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
+++ b/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
@@ -10,6 +10,7 @@ import net.osmtracker.db.TrackContentProvider;
 import net.osmtracker.overlay.WayPointsOverlay;
 
 import org.osmdroid.api.IMapController;
+import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.tilesource.ITileSource;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
 import org.osmdroid.util.GeoPoint;
@@ -164,6 +165,7 @@ public class DisplayTrackMap extends Activity {
 		setTitle(getTitle() + ": #" + currentTrackId);
 		
 		// Initialize OSM view
+		Configuration.getInstance().load(this, prefs);
 		osmView = (MapView) findViewById(R.id.displaytrackmap_osmView);
 		osmView.setMultiTouchControls(true);  // pinch to zoom
 		// we'll use osmView to define if the screen is always on or not

--- a/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
+++ b/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
@@ -155,15 +155,15 @@ public class DisplayTrackMap extends Activity {
 	@Override
 	public void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		
+
 		// loading the preferences
 		prefs = PreferenceManager.getDefaultSharedPreferences(this);
-		
+
 		setContentView(R.layout.displaytrackmap);
-		
+
 		currentTrackId = getIntent().getExtras().getLong(TrackContentProvider.Schema.COL_TRACK_ID);
 		setTitle(getTitle() + ": #" + currentTrackId);
-		
+
 		// Initialize OSM view
 		Configuration.getInstance().load(this, prefs);
 		osmView = (MapView) findViewById(R.id.displaytrackmap_osmView);
@@ -171,7 +171,7 @@ public class DisplayTrackMap extends Activity {
 		// we'll use osmView to define if the screen is always on or not
 		osmView.setKeepScreenOn(prefs.getBoolean(OSMTracker.Preferences.KEY_UI_DISPLAY_KEEP_ON, OSMTracker.Preferences.VAL_UI_DISPLAY_KEEP_ON));
 		osmViewController = osmView.getController();
-		
+
 		// Check if there is a saved zoom level
 		if(savedInstanceState != null) {
 			osmViewController.setZoom(savedInstanceState.getInt(CURRENT_ZOOM, DEFAULT_ZOOM));
@@ -184,7 +184,7 @@ public class DisplayTrackMap extends Activity {
 			SharedPreferences settings = getPreferences(MODE_PRIVATE);
 			osmViewController.setZoom(settings.getInt(LAST_ZOOM, DEFAULT_ZOOM));
 		}
-		
+
 		selectTileSource();
 
 		createOverlays();
@@ -196,7 +196,7 @@ public class DisplayTrackMap extends Activity {
 				pathChanged();
 			}
 		};
-		
+
 		// Register listeners for zoom buttons
 		findViewById(R.id.displaytrackmap_imgZoomIn).setOnClickListener( new OnClickListener() {
 			@Override
@@ -217,6 +217,7 @@ public class DisplayTrackMap extends Activity {
 	 */
 	public void selectTileSource() {
 		String mapTile = prefs.getString(OSMTracker.Preferences.KEY_UI_MAP_TILE, OSMTracker.Preferences.VAL_UI_MAP_TILE_MAPNIK);
+		Log.e("TileMapName active", mapTile);
 		osmView.setTileSource(selectMapTile(mapTile));
 	}
 	
@@ -233,7 +234,8 @@ public class DisplayTrackMap extends Activity {
 			return (ITileSource) f.get(null); 
 		} catch (Exception e) {
 			Log.e(TAG, "Invalid tile source '"+mapTile+"'", e);
-			return TileSourceFactory.MAPNIK;
+			Log.e(TAG, "Default tile source selected: '" + TileSourceFactory.DEFAULT_TILE_SOURCE.name() +"'");
+			return TileSourceFactory.DEFAULT_TILE_SOURCE;
 		}
 	}
 
@@ -251,31 +253,36 @@ public class DisplayTrackMap extends Activity {
 
 	@Override
 	protected void onResume() {
-		
+
+		super.onResume();
+		resumeActivity();
+
+	}
+
+	private void resumeActivity(){
 		// setKeepScreenOn depending on user's preferences
 		osmView.setKeepScreenOn(prefs.getBoolean(OSMTracker.Preferences.KEY_UI_DISPLAY_KEEP_ON, OSMTracker.Preferences.VAL_UI_DISPLAY_KEEP_ON));
-		
+
 		// Register content observer for any trackpoint changes
 		getContentResolver().registerContentObserver(
 				TrackContentProvider.trackPointsUri(currentTrackId),
 				true, trackpointContentObserver);
-		
+
 		// Forget the last waypoint read from the DB
-		// This ensures that all waypoints for the track will be reloaded 
+		// This ensures that all waypoints for the track will be reloaded
 		// from the database to populate the path layout
 		lastTrackPointIdProcessed = null;
-		
+
 		// Reload path
 		pathChanged();
 
 		selectTileSource();
-		
+
 		// Refresh way points
-		// wayPointsOverlay.refresh();
-		
-		super.onResume();
+		wayPointsOverlay.refresh();
+
 	}
-	
+
 	@Override
 	protected void onPause() {
 		// Unregister content observer

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,63 +1,117 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
-	<ListPreference android:title="@string/prefs_voicerec_duration"
-		android:key="voicerec.duration" android:entryValues="@array/prefs_voicerec_durations"
-		android:defaultValue="2" android:entries="@array/prefs_voicerec_durations"></ListPreference>
-	<CheckBoxPreference android:key="sound_enabled" android:title="@string/prefs_sound_enabled"
-		android:summary="@string/prefs_sound_enabled_summary" android:defaultValue="true"></CheckBoxPreference>
+	<ListPreference
+		android:title="@string/prefs_voicerec_duration"
+		android:key="voicerec.duration"
+		android:entryValues="@array/prefs_voicerec_durations"
+		android:defaultValue="2"
+		android:entries="@array/prefs_voicerec_durations" />
+	<CheckBoxPreference
+		android:key="sound_enabled"
+		android:title="@string/prefs_sound_enabled"
+		android:summary="@string/prefs_sound_enabled_summary"
+		android:defaultValue="true" />
 	<com.android.internal.preference.YesNoPreference android:key="osm.oauth.clear-data"
 		android:title="@string/prefs_osm_clear_oauth_data" android:summary="@string/prefs_osm_clear_oauth_data_summary"
 		android:dialogMessage="@string/prefs_osm_clear_oauth_data_dialog" android:dialogIcon="@android:drawable/ic_dialog_alert" />
 	
 	<PreferenceCategory android:title="@string/prefs_gps">
-		<Preference android:summary="@string/prefs_gps_os_settings_summary"
-			android:title="@string/prefs_gps_os_settings" android:key="gps.ossettings"></Preference>
-		<CheckBoxPreference android:key="gps.checkstartup"
-			android:title="@string/prefs_check_gps_startup" android:summary="@string/prefs_check_gps_startup_summary"
-			android:defaultValue="true"></CheckBoxPreference>
-		<CheckBoxPreference android:key="gps.ignoreclock"
-			android:title="@string/prefs_gps_ignore_clock" android:summary="@string/prefs_gps_ignore_clock_summary"
-			android:defaultValue="false"></CheckBoxPreference>
-		<EditTextPreference android:key="gps.logging.interval"
-			android:title="@string/prefs_gps_logging_interval" android:summary="@string/prefs_gps_logging_interval_summary"
-			android:defaultValue="0" android:inputType="number"></EditTextPreference>
-		<EditTextPreference android:key="gps.logging.min_distance"
-			android:title="@string/prefs_gps_logging_min_distance" android:summary="@string/prefs_gps_logging_min_distance_summary"
-			android:defaultValue="0" android:inputType="number"></EditTextPreference>
+		<Preference
+			android:summary="@string/prefs_gps_os_settings_summary"
+			android:title="@string/prefs_gps_os_settings"
+			android:key="gps.ossettings" />
+		<CheckBoxPreference
+			android:key="gps.checkstartup"
+			android:title="@string/prefs_check_gps_startup"
+			android:summary="@string/prefs_check_gps_startup_summary"
+			android:defaultValue="true" />
+		<CheckBoxPreference
+			android:key="gps.ignoreclock"
+			android:title="@string/prefs_gps_ignore_clock"
+			android:summary="@string/prefs_gps_ignore_clock_summary"
+			android:defaultValue="false" />
+		<EditTextPreference
+			android:key="gps.logging.interval"
+			android:title="@string/prefs_gps_logging_interval"
+			android:summary="@string/prefs_gps_logging_interval_summary"
+			android:defaultValue="0"
+			android:inputType="number" />
+		<EditTextPreference
+			android:key="gps.logging.min_distance"
+			android:title="@string/prefs_gps_logging_min_distance"
+			android:summary="@string/prefs_gps_logging_min_distance_summary"
+			android:defaultValue="0"
+			android:inputType="number" />
 	</PreferenceCategory>
 	
 	<PreferenceCategory android:title="@string/prefs_output">
 		<EditTextPreference android:key="logging.storage.dir"
 			android:defaultValue="/osmtracker" android:title="@string/prefs_storage_dir" android:dialogMessage="@string/prefs_storage_dir_hint"/>
-		<CheckBoxPreference android:key="gpx.directory_per_track" android:title="@string/prefs_output_one_dir_per_track"
-			android:summary="@string/prefs_output_one_dir_per_track_summary" android:defaultValue="true"></CheckBoxPreference>
+		<CheckBoxPreference
+			android:key="gpx.directory_per_track"
+			android:title="@string/prefs_output_one_dir_per_track"
+			android:summary="@string/prefs_output_one_dir_per_track_summary"
+			android:defaultValue="true" />
 		<ListPreference android:key="gpx.filename" android:defaultValue="name_date" android:summary="@string/prefs_output_filename_summary"
 			android:title="@string/prefs_output_filename" android:entryValues="@array/prefs_output_filename_values"
 			android:entries="@array/prefs_output_filename_keys" />
-		<ListPreference android:key="gpx.accuracy" android:defaultValue="none" android:summary="@string/prefs_output_accuracy_summary"
-			android:title="@string/prefs_output_accuracy" android:entryValues="@array/prefs_output_accuracy_values"
-			android:entries="@array/prefs_output_accuracy_keys"></ListPreference>
-		<CheckBoxPreference android:key="gpx.hdop.approximation" android:title="@string/prefs_output_gpx_hdop_approximation"
-			android:summary="@string/prefs_output_gpx_hdop_approximation_summary" android:defaultValue="false"></CheckBoxPreference>
+		<ListPreference
+			android:key="gpx.accuracy"
+			android:defaultValue="none"
+			android:summary="@string/prefs_output_accuracy_summary"
+			android:title="@string/prefs_output_accuracy"
+			android:entryValues="@array/prefs_output_accuracy_values"
+			android:entries="@array/prefs_output_accuracy_keys" />
+		<CheckBoxPreference
+			android:key="gpx.hdop.approximation"
+			android:title="@string/prefs_output_gpx_hdop_approximation"
+			android:summary="@string/prefs_output_gpx_hdop_approximation_summary"
+			android:defaultValue="false" />
 		<ListPreference android:key="gpx.compass_heading" android:summary="@string/prefs_compass_heading_summary" android:title="@string/prefs_compass_heading" android:entryValues="@array/prefs_compass_heading_values" android:entries="@array/prefs_compass_heading_keys"/>
 	</PreferenceCategory>
 
 	<PreferenceCategory android:title="@string/prefs_ui">
-		<ListPreference android:defaultValue="none" android:key="ui.picture.source" android:title="@string/prefs_ui_picture_source"
-			android:summary="@string/prefs_ui_picture_source_summary" android:entries="@array/prefs_ui_picture_source_keys" android:entryValues="@array/prefs_ui_picture_source_values"></ListPreference>
-		<CheckBoxPreference android:key="ui.display_keep_on" android:title="@string/prefs_display_always_on"
-			android:summary="@string/prefs_display_always_on_summary" android:defaultValue="true"></CheckBoxPreference>
-		<ListPreference android:entries="@array/prefs_theme_keys" android:title="@string/prefs_theme"
-			android:entryValues="@array/prefs_theme_values" android:key="ui.theme" android:summary="@string/prefs_theme_summary" android:defaultValue="@style/DefaultTheme"></ListPreference>
+		<ListPreference
+			android:defaultValue="none"
+			android:key="ui.picture.source"
+			android:title="@string/prefs_ui_picture_source"
+			android:summary="@string/prefs_ui_picture_source_summary"
+			android:entries="@array/prefs_ui_picture_source_keys"
+			android:entryValues="@array/prefs_ui_picture_source_values" />
+		<CheckBoxPreference
+			android:key="ui.display_keep_on"
+			android:title="@string/prefs_display_always_on"
+			android:summary="@string/prefs_display_always_on_summary"
+			android:defaultValue="true" />
+		<ListPreference
+			android:entries="@array/prefs_theme_keys"
+			android:title="@string/prefs_theme"
+			android:entryValues="@array/prefs_theme_values"
+			android:key="ui.theme"
+			android:summary="@string/prefs_theme_summary"
+			android:defaultValue="@style/DefaultTheme" />
 		<PreferenceScreen android:title="@string/prefs_ui_buttons_layout" android:summary="@string/prefs_ui_buttons_layout_summary">
-			<intent android:action="launch_buttons_presets"></intent>
+			<intent android:action="launch_buttons_presets" />
 		</PreferenceScreen>
-		<CheckBoxPreference android:key="ui.displaytrack.osm" android:title="@string/prefs_displaytrack_osm"
-			android:summary="@string/prefs_displaytrack_osm_summary" android:defaultValue="false"></CheckBoxPreference>
-		<ListPreference android:entries="@array/prefs_map_tile_keys" android:title="@string/prefs_map_tile"
-			android:entryValues="@array/prefs_map_tile_values" android:key="ui.map.tile" android:summary="@string/prefs_map_tile_summary" android:defaultValue="MAPNIK"></ListPreference>
-		<ListPreference android:defaultValue="none" android:key="ui.orientation" android:title="@string/prefs_ui_orientation"
-			android:summary="@string/prefs_ui_orientation_summary" android:entries="@array/prefs_ui_orientation_options_keys" android:entryValues="@array/prefs_ui_orientation_options_values"></ListPreference>
+		<CheckBoxPreference
+			android:key="ui.displaytrack.osm"
+			android:title="@string/prefs_displaytrack_osm"
+			android:summary="@string/prefs_displaytrack_osm_summary"
+			android:defaultValue="false" />
+		<ListPreference
+			android:entries="@array/prefs_map_tile_keys"
+			android:title="@string/prefs_map_tile"
+			android:entryValues="@array/prefs_map_tile_values"
+			android:key="ui.map.tile"
+			android:summary="@string/prefs_map_tile_summary"
+			android:defaultValue="MAPNIK" />
+		<ListPreference
+			android:defaultValue="none"
+			android:key="ui.orientation"
+			android:title="@string/prefs_ui_orientation"
+			android:summary="@string/prefs_ui_orientation_summary"
+			android:entries="@array/prefs_ui_orientation_options_keys"
+			android:entryValues="@array/prefs_ui_orientation_options_values" />
 	</PreferenceCategory>
 
 


### PR DESCRIPTION
In this PR is added a method which sets the osmdroid HTTP User Agent to the application's package name. This avoid using the osmdroid default user agent (banned in osm servers). More info [here](https://github.com/osmdroid/osmdroid/wiki/How-to-use-the-osmdroid-library). 

This PR fixes the issue #194 and #195.

Note: Travic Ci will fail since this PR is based on develop branch as it is now (before the eventual merge of #202)