### PR TITLE
Record trackpoints after runtime GPS permission is granted during track recording. Fixes issue #207

### DIFF
--- a/app/src/main/java/net/osmtracker/OSMTracker.java
+++ b/app/src/main/java/net/osmtracker/OSMTracker.java
@@ -124,6 +124,12 @@ public class OSMTracker {
 	public final static String INTENT_START_TRACKING = OSMTracker.PACKAGE_NAME + ".intent.START_TRACKING";
 
 	/**
+	 * Intent to re-register our {@code GPSLogger} service as a location listener.
+	 * Needed after a new track recording begins and then user grants permission.ACCESS_FINE_LOCATION.
+	 */
+	public final static String INTENT_REREG_LOC_LISTENER = OSMTracker.PACKAGE_NAME + ".intent.REREG_LOC_LISTENER";
+
+	/**
 	 * Intent to stop tracking
 	 */
 	public final static String INTENT_STOP_TRACKING = OSMTracker.PACKAGE_NAME + ".intent.STOP_TRACKING";

--- a/app/src/main/java/net/osmtracker/activity/TrackLogger.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackLogger.java
@@ -76,7 +76,14 @@ public class TrackLogger extends Activity {
 	private static final String TAG = TrackLogger.class.getSimpleName();
 
 	final private int RC_STORAGE_AUDIO_PERMISSIONS = 1;
+
 	final private int RC_STORAGE_CAMERA_PERMISSIONS = 2;
+
+	/**
+	 * Request GPS permissions; used by {@link GpsStatusRecord} widget
+	 * which calls {@code ActivityCompat.requestPermissions} if needed
+	 */
+	final static public int RC_GPS_PERMISSIONS = 3;
 
 	/**
 	 * Request code for callback after the camera application had taken a
@@ -845,6 +852,18 @@ public class TrackLogger extends Activity {
 					// permission denied, boo! Disable the
 					// functionality that depends on this permission.
 					//TODO: add an informative message.
+				}
+				return;
+			}
+
+			case RC_GPS_PERMISSIONS: {
+				if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+					((GpsStatusRecord) findViewById(R.id.gpsStatus)).requestLocationUpdates(true);
+					sendBroadcast(new Intent(OSMTracker.INTENT_REREG_LOC_LISTENER));
+				} else {
+					// permission denied!
+					//TODO: add an informative message.
+					((GpsStatusRecord) findViewById(R.id.gpsStatus)).requestLocationUpdates(false);
 				}
 				return;
 			}

--- a/app/src/main/java/net/osmtracker/layout/GpsStatusRecord.java
+++ b/app/src/main/java/net/osmtracker/layout/GpsStatusRecord.java
@@ -40,8 +40,6 @@ public class GpsStatusRecord extends LinearLayout implements Listener, LocationL
 	
 	private final static String TAG = GpsStatusRecord.class.getSimpleName();
 
-    final private int REQUEST_CODE_GPS_PERMISSIONS = 1;
-
 	/**
 	 * Formatter for accuracy display.
 	 */
@@ -124,7 +122,7 @@ public class GpsStatusRecord extends LinearLayout implements Listener, LocationL
             }
 			else {
                     ActivityCompat.requestPermissions((Activity) activity, new String[]{Manifest.permission.ACCESS_FINE_LOCATION},
-                            REQUEST_CODE_GPS_PERMISSIONS);
+                            TrackLogger.RC_GPS_PERMISSIONS);
                 }
 		} else {
 			lmgr.removeUpdates(this);
@@ -270,19 +268,6 @@ public class GpsStatusRecord extends LinearLayout implements Listener, LocationL
 			recordStatus.setImageResource(R.drawable.record_red);
 		} else {
 			recordStatus.setImageResource(R.drawable.record_grey);
-		}
-	}
-
-	public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
-		switch (requestCode) {
-			case REQUEST_CODE_GPS_PERMISSIONS:
-				if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-					requestLocationUpdates(true);
-					// do something
-					return;
-				} else {
-					requestLocationUpdates(false);
-				}
 		}
 	}
 


### PR DESCRIPTION
Fix issue #207.  Tested on emulator and android 9 device with all of these scenarios:
- Remove app's Location permission, start new track, give permission
- Clear app data/permissions, start new track, give permission
- Uninstall/reinstall app

