### PR TITLE
Map scale up

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
+++ b/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
@@ -187,6 +187,8 @@ public class DisplayTrackMap extends Activity {
 
 		selectTileSource();
 
+        setTileDpiScaling();
+
 		createOverlays();
 
 		// Create content observer for trackpoints
@@ -220,6 +222,14 @@ public class DisplayTrackMap extends Activity {
 		Log.e("TileMapName active", mapTile);
 		osmView.setTileSource(selectMapTile(mapTile));
 	}
+
+    /**
+     * Make text on map better readable on high DPI displays
+     */
+    public void setTileDpiScaling () {
+        osmView.setTilesScaledToDpi(true);
+    }
+
 	
 	/**
 	 * Returns a ITileSource for the map according to the selected mapTile
@@ -278,6 +288,8 @@ public class DisplayTrackMap extends Activity {
 
 		selectTileSource();
 
+		setTileDpiScaling();
+		
 		// Refresh way points
 		wayPointsOverlay.refresh();
 

--- a/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
+++ b/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
@@ -28,6 +28,7 @@ import android.graphics.Color;
 import android.os.Bundle;
 import android.os.Handler;
 import android.preference.PreferenceManager;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -367,7 +368,12 @@ public class DisplayTrackMap extends Activity {
 	 * Creates overlays over the OSM view
 	 */
 	private void createOverlays() {
-		pathOverlay = new PathOverlay(Color.BLUE, this);
+		DisplayMetrics metrics = new DisplayMetrics();
+		this.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+
+		// set with to hopefully DPI independent 0.5mm
+ 		pathOverlay = new PathOverlay(Color.BLUE, (float)(metrics.densityDpi / 25.4 / 2),this);
+
 		osmView.getOverlays().add(pathOverlay);
 		
 		myLocationOverlay = new SimpleLocationOverlay(this);


### PR DESCRIPTION
This PR was created instead of [this PR](https://github.com/labexp/osmtracker-android/pull/192) originally created by @icrf2000. 
It improves the visualization in the map as shown in the following picture.
- The image at the **left** shows the map with the changes of this PR
- The image at the **right** shows how the map looks like without this PR
![imagen](https://user-images.githubusercontent.com/26278460/59114267-0a77ab00-8904-11e9-8d81-2b0fcb29ef04.png)
