### PR TITLE
Avoid choosing the MapTileSource in app preferences. Let Mapnik by default.

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
+++ b/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
@@ -218,26 +218,27 @@ public class DisplayTrackMap extends Activity {
 	public void selectTileSource() {
 		String mapTile = prefs.getString(OSMTracker.Preferences.KEY_UI_MAP_TILE, OSMTracker.Preferences.VAL_UI_MAP_TILE_MAPNIK);
 		Log.e("TileMapName active", mapTile);
-		osmView.setTileSource(selectMapTile(mapTile));
+		//osmView.setTileSource(selectMapTile(mapTile));
+		osmView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
 	}
 	
-	/**
-	 * Returns a ITileSource for the map according to the selected mapTile
-	 * String. The default is mapnik.
-	 * 
-	 * @param mapTile String that is the name of the tile provider
-	 * @return ITileSource with the selected Tile-Source
-	 */
-	private ITileSource selectMapTile(String mapTile) {
-		try {
-			Field f = TileSourceFactory.class.getField(mapTile);
-			return (ITileSource) f.get(null); 
-		} catch (Exception e) {
-			Log.e(TAG, "Invalid tile source '"+mapTile+"'", e);
-			Log.e(TAG, "Default tile source selected: '" + TileSourceFactory.DEFAULT_TILE_SOURCE.name() +"'");
-			return TileSourceFactory.DEFAULT_TILE_SOURCE;
-		}
-	}
+//	/**
+//	 * Returns a ITileSource for the map according to the selected mapTile
+//	 * String. The default is mapnik.
+//	 *
+//	 * @param mapTile String that is the name of the tile provider
+//	 * @return ITileSource with the selected Tile-Source
+//	 */
+//	private ITileSource selectMapTile(String mapTile) {
+//		try {
+//			Field f = TileSourceFactory.class.getField(mapTile);
+//			return (ITileSource) f.get(null);
+//		} catch (Exception e) {
+//			Log.e(TAG, "Invalid tile source '"+mapTile+"'", e);
+//			Log.e(TAG, "Default tile source selected: '" + TileSourceFactory.DEFAULT_TILE_SOURCE.name() +"'");
+//			return TileSourceFactory.DEFAULT_TILE_SOURCE;
+//		}
+//	}
 
 
 	@Override

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -98,13 +98,13 @@
 			android:title="@string/prefs_displaytrack_osm"
 			android:summary="@string/prefs_displaytrack_osm_summary"
 			android:defaultValue="false" />
-		<ListPreference
+		<!--<ListPreference
 			android:entries="@array/prefs_map_tile_keys"
 			android:title="@string/prefs_map_tile"
 			android:entryValues="@array/prefs_map_tile_values"
 			android:key="ui.map.tile"
 			android:summary="@string/prefs_map_tile_summary"
-			android:defaultValue="MAPNIK" />
+			android:defaultValue="MAPNIK" />-->
 		<ListPreference
 			android:defaultValue="none"
 			android:key="ui.orientation"


### PR DESCRIPTION
This PR fix issue #96, #125, #127 

![mapTileSources](https://user-images.githubusercontent.com/29348322/59120257-313cde00-8912-11e9-9360-1e4b52f2f089.png)

The options `CycleMap` and `MapQuest` are not available any more for using them in the app.

The only source available that woks in the same way is MAPNIK so we decided that, by the moment, the app will use by default the MAPNIK tile source. If this is the best for the app and users, we can let this change be permanent.

With this PR the map tile source can not be changed. This is for avoiding exceptions and because MAPNIK will be used anyway if the selected source does not work correctly (throws an exception) and this will happen if `MapQuest` or `CycleMap` are chosen.

In conclusion the functionality of choosing the map tile source was useless right now. 
