### PR TITLE
Fix issue #122

### DIFF
--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -35,6 +35,7 @@ import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
+import android.widget.Toast;
 
 /**
  * Base class to writes a GPX file and export
@@ -189,6 +190,8 @@ public abstract class ExportTrackTask  extends AsyncTask<Void, Long, Boolean> {
 					}
 				})
 				.show();
+		}else{
+			Toast.makeText(this.context, R.string.various_export_finished, Toast.LENGTH_SHORT).show();
 		}
 	}
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,6 +147,7 @@
 	<string name="various_heading_display">{0}&#176;</string> <!-- parameters: (heading in degrees) -->
 	<string name="various_heading">Wait for heading&#8230;</string>
 	<string name="various_heading_unknown">Heading can\'t be determined</string>
+	<string name="various_export_finished">Export process finished successfully</string>
 	
 
 	<!-- OSM map view -->


### PR DESCRIPTION
In the TrackDetail activity, the `export as gpx` button shows a dialog while does the task but when the track is small this dialog appears very shortly and the app says nothing after it disappears. This PR notifies when gpx export finishes showing a Toast.