### PR TITLE
Fix gpx filename

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -38,7 +38,6 @@ import net.osmtracker.util.FileSystemUtils;
 
 import java.io.File;
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
@@ -523,7 +522,6 @@ public class TrackManager extends ListActivity {
 		
 		// Create entry in TRACK table
 		ContentValues values = new ContentValues();
-		//values.put(TrackContentProvider.Schema.COL_NAME, DATE_FORMAT.format(new Date(startDate.getTime())));
         values.put(TrackContentProvider.Schema.COL_NAME, DataHelper.FILENAME_FORMATTER.format(new Date()));
         values.put(TrackContentProvider.Schema.COL_START_DATE, startDate.getTime());
 		values.put(TrackContentProvider.Schema.COL_ACTIVE, TrackContentProvider.Schema.VAL_TRACK_ACTIVE);

--- a/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
@@ -1,18 +1,18 @@
 package net.osmtracker.gpx;
 
-import java.io.File;
-import java.util.Date;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Environment;
+import android.preference.PreferenceManager;
+import android.util.Log;
 
 import net.osmtracker.OSMTracker;
 import net.osmtracker.R;
 import net.osmtracker.db.DataHelper;
 import net.osmtracker.exception.ExportTrackException;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.os.Environment;
-import android.preference.PreferenceManager;
-import android.util.Log;
+import java.io.File;
+import java.util.Date;
 
 /**
  * Exports to the external storage / SD card

--- a/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
@@ -9,7 +9,6 @@ import android.util.Log;
 
 import net.osmtracker.OSMTracker;
 import net.osmtracker.R;
-import net.osmtracker.db.DataHelper;
 import net.osmtracker.db.TrackContentProvider;
 import net.osmtracker.exception.ExportTrackException;
 
@@ -49,8 +48,6 @@ public class ExportToStorageTask extends ExportTrackTask {
 
 		if (directoryPerTrack) {
 
-			// At least use the start date as the folder name
-			String trackIsoDate =  DataHelper.FILENAME_FORMATTER.format(startDate);
 			String trackName = "";
 
 			// Get the name of the track with the received start date
@@ -59,22 +56,15 @@ public class ExportToStorageTask extends ExportTrackTask {
 
 			Cursor c = context.getContentResolver().query(
 					TrackContentProvider.CONTENT_URI_TRACK, null, selection, args, null);
-
+			
 			if(c != null && c.moveToFirst()){
 				int i = c.getColumnIndex(TrackContentProvider.Schema.COL_NAME);
 				trackName = c.getString(i);
 			}
 			if(trackName != null && trackName.length() >= 1) {
-
 				trackName = trackName.replace("/", "_");
-				// Don't repeat dates if the track name = date format
-				if(!trackName.equals(trackIsoDate))
-					perTrackDirectory = File.separator + trackName.trim() + "_" + trackIsoDate;
-				else
-					perTrackDirectory = File.separator + trackName.trim();
+				perTrackDirectory = File.separator + trackName.trim();
 			}
-			else
-				perTrackDirectory = File.separator + trackIsoDate;
 
 		}
 		

--- a/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
@@ -65,8 +65,13 @@ public class ExportToStorageTask extends ExportTrackTask {
 				trackName = c.getString(i);
 			}
 			if(trackName != null && trackName.length() >= 1) {
+
 				trackName = trackName.replace("/", "_");
-				perTrackDirectory = File.separator + trackName.trim() + "_" + trackIsoDate;
+				// Don't repeat dates if the track name = date format
+				if(!trackName.equals(trackIsoDate))
+					perTrackDirectory = File.separator + trackName.trim() + "_" + trackIsoDate;
+				else
+					perTrackDirectory = File.separator + trackName.trim();
 			}
 			else
 				perTrackDirectory = File.separator + trackIsoDate;

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -553,21 +553,6 @@ public abstract class ExportTrackTask  extends AsyncTask<Void, Long, Boolean> {
 			filenameBase.append(sanitized);
 		}
 
-		if ((filenameBase.length() == 0)
-			|| ! filenameOutput.equals(OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME)) {
-
-			final long startDateLong = c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_START_DATE));
-
-			Date startDate = new Date(startDateLong);
-			String defaultTrackName = DataHelper.FILENAME_FORMATTER.format(new Date(startDate.getTime()));
-
-			// Don't repeat dates if the track name = date format
-			if (!tname.equals(defaultTrackName)) {
-				filenameBase.append('_');
-				filenameBase.append(DataHelper.FILENAME_FORMATTER.format(new Date(startDateLong)));
-			}
-		}
-
 		filenameBase.append(DataHelper.EXTENSION_GPX);
 		return filenameBase.toString();
 	}

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -31,7 +31,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.net.URLEncoder;
-import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -118,8 +117,6 @@ public abstract class ExportTrackTask  extends AsyncTask<Void, Long, Boolean> {
 	 * @return
 	 */
 	protected abstract boolean updateExportDate();
-
-	private static final DateFormat DATE_FORMAT = DateFormat.getDateTimeInstance();
 
 	public ExportTrackTask(Context context, long... trackIds) {
 		this.context = context;
@@ -562,9 +559,9 @@ public abstract class ExportTrackTask  extends AsyncTask<Void, Long, Boolean> {
 			final long startDateLong = c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_START_DATE));
 
 			Date startDate = new Date(startDateLong);
-			String defaultTrackName = DATE_FORMAT.format(new Date(startDate.getTime()));
+			String defaultTrackName = DataHelper.FILENAME_FORMATTER.format(new Date(startDate.getTime()));
 
-			// Check if the current name = defaultTrackName which is a date format
+			// Don't repeat dates if the track name = date format
 			if (!tname.equals(defaultTrackName)) {
 				filenameBase.append('_');
 				filenameBase.append(DataHelper.FILENAME_FORMATTER.format(new Date(startDateLong)));


### PR DESCRIPTION
Avoid dates duplication in directories name and gpx files-name when exporting without changing the track names manually.

This happens anytime you export a track without editing it's name.
MIght be related to issues #161 and #162.