### PR TITLE
Save button doesn't appear in tracklogger activity

### DIFF
--- a/app/src/main/res/menu/tracklogger_menu.xml
+++ b/app/src/main/res/menu/tracklogger_menu.xml
@@ -5,7 +5,7 @@
 		android:id="@+id/tracklogger_menu_stoptracking"
 		android:title="@string/menu_stoptracking"
 		android:icon="@android:drawable/ic_menu_save"
-		app:showAsAction="ifRoom|withText" />
+		android:showAsAction="ifRoom|withText" />
 	<item
 		android:id="@+id/tracklogger_menu_waypointlist"
 		android:title="@string/menu_waypointlist"


### PR DESCRIPTION
Changing the `app` attribute in tracklogger_menu.xml and using `android` instead solves the issue #235 
![Captura de pantalla de 2020-02-21 10-18-54](https://user-images.githubusercontent.com/26258845/75052209-d560b800-5494-11ea-9c1c-f12b1f7e3f80.png)
