### PR TITLE
Sharing feature

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/OpenStreetMapUpload.java
+++ b/app/src/main/java/net/osmtracker/activity/OpenStreetMapUpload.java
@@ -1,5 +1,18 @@
 package net.osmtracker.activity;
 
+import android.content.ContentUris;
+import android.content.SharedPreferences;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.util.Log;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.Toast;
+
 import net.osmtracker.OSMTracker;
 import net.osmtracker.R;
 import net.osmtracker.db.TrackContentProvider;
@@ -13,18 +26,6 @@ import net.osmtracker.osm.UploadToOpenStreetMapTask;
 import oauth.signpost.OAuth;
 import oauth.signpost.commonshttp.CommonsHttpOAuthConsumer;
 import oauth.signpost.commonshttp.CommonsHttpOAuthProvider;
-import android.content.ContentUris;
-import android.content.SharedPreferences;
-import android.database.Cursor;
-import android.net.Uri;
-import android.os.Bundle;
-import android.preference.PreferenceManager;
-import android.util.Log;
-import android.view.View;
-import android.view.View.OnClickListener;
-import android.view.WindowManager;
-import android.widget.Button;
-import android.widget.Toast;
 
 /**
  * <p>Uploads a track on OSM using the API and
@@ -66,7 +67,7 @@ public class OpenStreetMapUpload extends TrackDetailEditor {
 				}
 			}
 		});
-				
+
 		final Button btnCancel = (Button) findViewById(R.id.osm_upload_btn_cancel);
 		btnCancel.setOnClickListener(new OnClickListener() {
 			@Override

--- a/app/src/main/java/net/osmtracker/activity/TrackDetailEditor.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackDetailEditor.java
@@ -114,8 +114,8 @@ public abstract class TrackDetailEditor extends Activity {
 
         // If no changes were made don't append the date
 		if ((enteredName.length() > 0 && !enteredName.equals(tname))) {
-			// Append date to avoid duplicated tracks names
-			enteredName += "_" + defaultDate;
+			// Append date to avoid duplicated tracks names only if is not included already
+			if(!enteredName.contains(defaultDate)) enteredName += "_" + defaultDate;
 			values.put(TrackContentProvider.Schema.COL_NAME, enteredName);
 		}
 		

--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -558,7 +558,7 @@ public class TrackManager extends ListActivity {
 	private void prepareAndShareTrack(long trackId) {
 		final Context context = this;
 		// Create temp file that will remain in cache
-		new ExportToTempFileTask(this, trackId){
+		new ExportToTempFileTask(this, trackId, getContentResolver()){
 			@Override
 			protected void executionCompleted(){
 				shareFile(this.getTmpFile());

--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -433,7 +433,16 @@ public class TrackManager extends ListActivity {
 			break;
 
 		case R.id.trackmgr_contextmenu_share:
-			shareTrack(info.id);
+			trackId = info.id;
+			if (!writeExternalStoragePermissionGranted()){
+				Log.e("DisplayTrackMapWrite", "Permission asked");
+				ActivityCompat.requestPermissions(this,
+						new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, RC_WRITE_PERMISSIONS_EXPORT_ONE);
+			}
+			else {
+				exportOneTrack();
+				shareTrack(info.id);
+			}
 			break;
 
 		case R.id.trackmgr_contextmenu_osm_upload:

--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -7,12 +7,10 @@ import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
-import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
@@ -425,6 +423,7 @@ public class TrackManager extends ListActivity {
 			break;
 
 		case R.id.trackmgr_contextmenu_export:
+			trackId = info.id;
 			if (!writeExternalStoragePermissionGranted()){
 				Log.e("DisplayTrackMapWrite", "Permission asked");
 				ActivityCompat.requestPermissions(this,
@@ -545,31 +544,8 @@ public class TrackManager extends ListActivity {
 	 */
 	private void shareTrack(long trackId) {
 
-		Uri trackUri = ContentUris.withAppendedId(TrackContentProvider.CONTENT_URI_TRACK, trackId);
-
-		Cursor cursor = getContentResolver().query(trackUri, null, null,
-				null, null);
-
-		String trackName = "";
-		if(cursor != null && cursor.moveToFirst()) {
-			trackName = cursor.getString(cursor.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
-			cursor.close();
-		}
-
-		File sdRoot = Environment.getExternalStorageDirectory();
-
-		// The location where the user has specified gpx files and associated content to be written
-		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-		String userGPXExportDirectoryName = prefs.getString(
-				OSMTracker.Preferences.KEY_STORAGE_DIR,	OSMTracker.Preferences.VAL_STORAGE_DIR);
-
-		// Build storage track path for file creation
-		String completeGPXTrackPath = sdRoot + userGPXExportDirectoryName.trim() +
-				File.separator + trackName.trim()  + File.separator +
-				trackName.trim() + DataHelper.EXTENSION_GPX;
-
 		// Get track gpx file
-		File trackGPX = new File(completeGPXTrackPath);
+		File trackGPX = DataHelper.getGPXTrackFile(trackId, getContentResolver(), this);
 
 		// Get gpx content URI
 		Uri trackUriContent = FileProvider.getUriForFile(this,

--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -450,7 +450,7 @@ public class TrackManager extends ListActivity {
 //			break;
 
 		case R.id.trackmgr_contextmenu_share:
-			prepareAndShareTrack(info.id);
+			prepareAndShareTrack(info.id, this);
 			break;
 
 		case R.id.trackmgr_contextmenu_osm_upload:
@@ -555,13 +555,15 @@ public class TrackManager extends ListActivity {
 		return trackId;
 	}
 
-	private void prepareAndShareTrack(long trackId) {
-		final Context context = this;
+	// This should be static because contains an AsyncTask
+	// AsyncTasks has to live inside a static environment
+	// That's why the Context is passed as a parameter
+	private static void prepareAndShareTrack(long trackId, Context context) {
 		// Create temp file that will remain in cache
-		new ExportToTempFileTask(this, trackId, getContentResolver()){
+		new ExportToTempFileTask(context, trackId, context.getContentResolver()){
 			@Override
 			protected void executionCompleted(){
-				shareFile(this.getTmpFile());
+				shareFile(this.getTmpFile(), context);
 			}
 		}.execute();
 	}
@@ -570,10 +572,10 @@ public class TrackManager extends ListActivity {
 	 * Allows user to share gpx file from storage to another app
 	 * @param trackId track identifier
 	 */
-	private void shareFile(File tmpGPXFile) {
+	private static void shareFile(File tmpGPXFile, Context context) {
 
 		// Get gpx content URI
-		Uri trackUriContent = FileProvider.getUriForFile(this,
+		Uri trackUriContent = FileProvider.getUriForFile(context,
 				DataHelper.FILE_PROVIDER_AUTHORITY,
                 tmpGPXFile);
 
@@ -582,7 +584,7 @@ public class TrackManager extends ListActivity {
 		shareIntent.setAction(Intent.ACTION_SEND);
 		shareIntent.putExtra(Intent.EXTRA_STREAM, trackUriContent);
 		shareIntent.setType(DataHelper.MIME_GPX_TYPE);
-		startActivity(Intent.createChooser(shareIntent, getResources().getText(R.string.trackmgr_contextmenu_share)));
+		context.startActivity(Intent.createChooser(shareIntent, context.getResources().getText(R.string.trackmgr_contextmenu_share)));
 
 	}
 	

--- a/app/src/main/java/net/osmtracker/db/DataHelper.java
+++ b/app/src/main/java/net/osmtracker/db/DataHelper.java
@@ -386,16 +386,8 @@ public class DataHelper {
 	}
 
 	public static File getGPXTrackFile(long trackId, ContentResolver contentResolver, Context context) {
-		Uri trackUri = ContentUris.withAppendedId(TrackContentProvider.CONTENT_URI_TRACK, trackId);
 
-		Cursor cursor = contentResolver.query(trackUri, null, null,
-				null, null);
-
-		String trackName = "";
-		if(cursor != null && cursor.moveToFirst()) {
-			trackName = cursor.getString(cursor.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
-			cursor.close();
-		}
+		String trackName = getTrackNameInDB(trackId, contentResolver);
 
 		File sdRoot = Environment.getExternalStorageDirectory();
 
@@ -410,6 +402,19 @@ public class DataHelper {
 				trackName.trim() + DataHelper.EXTENSION_GPX;
 
 		return new File(completeGPXTrackPath);
+	}
+
+	public static String getTrackNameInDB(long trackId, ContentResolver contentResolver) {
+		String trackName = "";
+		Uri trackUri = ContentUris.withAppendedId(TrackContentProvider.CONTENT_URI_TRACK, trackId);
+		Cursor cursor = contentResolver.query(trackUri, null, null,
+				null, null);
+		if(cursor != null && cursor.moveToFirst()) {
+			trackName = cursor.getString(cursor.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
+			cursor.close();
+		}
+
+		return trackName;
 	}
 
 }

--- a/app/src/main/java/net/osmtracker/db/DataHelper.java
+++ b/app/src/main/java/net/osmtracker/db/DataHelper.java
@@ -385,4 +385,31 @@ public class DataHelper {
 		return _return;
 	}
 
+	public static File getGPXTrackFile(long trackId, ContentResolver contentResolver, Context context) {
+		Uri trackUri = ContentUris.withAppendedId(TrackContentProvider.CONTENT_URI_TRACK, trackId);
+
+		Cursor cursor = contentResolver.query(trackUri, null, null,
+				null, null);
+
+		String trackName = "";
+		if(cursor != null && cursor.moveToFirst()) {
+			trackName = cursor.getString(cursor.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
+			cursor.close();
+		}
+
+		File sdRoot = Environment.getExternalStorageDirectory();
+
+		// The location where the user has specified gpx files and associated content to be written
+		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+		String userGPXExportDirectoryName = prefs.getString(
+				OSMTracker.Preferences.KEY_STORAGE_DIR,	OSMTracker.Preferences.VAL_STORAGE_DIR);
+
+		// Build storage track path for file creation
+		String completeGPXTrackPath = sdRoot + userGPXExportDirectoryName.trim() +
+				File.separator + trackName.trim()  + File.separator +
+				trackName.trim() + DataHelper.EXTENSION_GPX;
+
+		return new File(completeGPXTrackPath);
+	}
+
 }

--- a/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
@@ -1,13 +1,16 @@
 package net.osmtracker.gpx;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Date;
-
-import net.osmtracker.exception.ExportTrackException;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
 import android.util.Log;
+
+import net.osmtracker.db.DataHelper;
+import net.osmtracker.exception.ExportTrackException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
 
 /**
  * Exports to a temporary file. Will not export associated
@@ -25,6 +28,18 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 		super(context, trackId);
 		try {
 			tmpFile = File.createTempFile("osm-upload", ".gpx", context.getCacheDir());
+			Log.d(TAG, "Temporary file: " + tmpFile.getAbsolutePath());
+		} catch (IOException ioe) {
+			Log.e(TAG, "Could not create temporary file", ioe);
+			throw new IllegalStateException("Could not create temporary file", ioe);
+		}
+	}
+
+	public ExportToTempFileTask(Context context, long trackId, ContentResolver contentResolver) {
+		super(context, trackId);
+		String trackName = DataHelper.getTrackNameInDB(trackId, contentResolver);
+		try {
+			tmpFile = File.createTempFile(trackName, ".gpx", context.getCacheDir());
 			Log.d(TAG, "Temporary file: " + tmpFile.getAbsolutePath());
 		} catch (IOException ioe) {
 			Log.e(TAG, "Could not create temporary file", ioe);

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -87,7 +87,7 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 	/**
 	 * Track IDs to export
 	 */
-	protected long[] trackIds;
+	private long[] trackIds;
 	
 	/**
 	 * Dialog to display while exporting
@@ -139,8 +139,8 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 	@Override
 	protected Boolean doInBackground(Void... params) {
 		try {
-			for (int i=0; i<trackIds.length; i++) {
-				exportTrackAsGpx(trackIds[i]);
+			for (long trackId : trackIds) {
+				exportTrackAsGpx(trackId);
 			}
 		} catch (ExportTrackException ete) {
 			errorMsg = ete.getMessage();
@@ -240,7 +240,7 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 						null, TrackContentProvider.Schema.COL_TIMESTAMP + " asc");
 
 				if (null != cTrackPoints && null != cWayPoints) {
-					publishProgress(new Long[]{trackId, (long) cTrackPoints.getCount(), (long) cWayPoints.getCount()});
+					publishProgress(trackId, (long) cTrackPoints.getCount(), (long) cWayPoints.getCount());
 
 					try {
 						writeGpxFile(track_name, tags, track_description, cTrackPoints, cWayPoints, trackFile);
@@ -356,23 +356,17 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 		int i=0;
 		for(c.moveToFirst(); !c.isAfterLast(); c.moveToNext(),i++) {
 			StringBuffer out = new StringBuffer();
-			out.append("\t\t\t" + "<trkpt lat=\"" 
-					+ c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LATITUDE)) + "\" "
-					+ "lon=\"" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LONGITUDE)) + "\">" + "\n");
+			out.append("\t\t\t" + "<trkpt lat=\"").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LATITUDE))).append("\" ").append("lon=\"").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LONGITUDE))).append("\">").append("\n");
 			if (! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION))) {
-				out.append("\t\t\t\t" + "<ele>" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION)) + "</ele>" + "\n");
+				out.append("\t\t\t\t" + "<ele>").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION))).append("</ele>").append("\n");
 			}
-			out.append("\t\t\t\t" + "<time>" + pointDateFormatter.format(new Date(c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_TIMESTAMP)))) + "</time>" + "\n");
+			out.append("\t\t\t\t" + "<time>").append(pointDateFormatter.format(new Date(c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_TIMESTAMP))))).append("</time>").append("\n");
 			
 			if(fillHDOP && ! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY))) {
-				out.append("\t\t\t\t" + "<hdop>" + (c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) / OSMTracker.HDOP_APPROXIMATION_FACTOR) + "</hdop>" + "\n");
+				out.append("\t\t\t\t" + "<hdop>").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) / OSMTracker.HDOP_APPROXIMATION_FACTOR).append("</hdop>").append("\n");
 			}
 			if(OSMTracker.Preferences.VAL_OUTPUT_COMPASS_COMMENT.equals(compass) && !c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))) {
-				out.append("\t\t\t\t" + "<cmt>"+CDATA_START+"compass: " + 
-							c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))+
-							"\n\t\t\t\t\tcompAccuracy: " + 
-							c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY))+
-				            CDATA_END+"</cmt>"+"\n");
+				out.append("\t\t\t\t" + "<cmt>" + CDATA_START + "compass: ").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))).append("\n\t\t\t\t\tcompAccuracy: ").append(c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY))).append(CDATA_END).append("</cmt>").append("\n");
 			}
 			
 			String buff = "";
@@ -425,14 +419,12 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 		
 		int i=0;
 		for(c.moveToFirst(); !c.isAfterLast(); c.moveToNext(), i++) {
-			StringBuffer out = new StringBuffer();
-			out.append("\t" + "<wpt lat=\""
-					+ c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LATITUDE)) + "\" "
-					+ "lon=\"" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LONGITUDE)) + "\">" + "\n");
+			StringBuilder out = new StringBuilder();
+			out.append("\t" + "<wpt lat=\"").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LATITUDE))).append("\" ").append("lon=\"").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LONGITUDE))).append("\">").append("\n");
 			if (! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION))) {
-				out.append("\t\t" + "<ele>" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION)) + "</ele>" + "\n");
+				out.append("\t\t" + "<ele>").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION))).append("</ele>").append("\n");
 			}
-			out.append("\t\t" + "<time>" + pointDateFormatter.format(new Date(c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_TIMESTAMP)))) + "</time>" + "\n");
+			out.append("\t\t" + "<time>").append(pointDateFormatter.format(new Date(c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_TIMESTAMP))))).append("</time>").append("\n");
 
 			String name = c.getString(c.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
 			
@@ -440,63 +432,54 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 				// Outputs accuracy info for way point
 				if (OSMTracker.Preferences.VAL_OUTPUT_ACCURACY_WPT_NAME.equals(accuracyInfo)) {
 					// Output accuracy with name
-					out.append("\t\t" + "<name>"
-							+ CDATA_START 
-							+ name
-							+ " (" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) + meterUnit + ")"
-							+ CDATA_END
-							+ "</name>" + "\n");
+					out.append("\t\t" + "<name>" + CDATA_START).append(name).append(" (").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY))).append(meterUnit).append(")").append(CDATA_END).append("</name>").append("\n");
 					if (OSMTracker.Preferences.VAL_OUTPUT_COMPASS_COMMENT.equals(compass) &&
 							! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))) {
-						out.append("\t\t"+ "<cmt>" + CDATA_START + "compass: " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS)) +
-								"\n\t\t\tcompass accuracy: " + c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY)) + CDATA_END + "</cmt>\n");
+						out.append("\t\t" + "<cmt>" + CDATA_START + "compass: ").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))).append("\n\t\t\tcompass accuracy: ").append(c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY))).append(CDATA_END).append("</cmt>\n");
 					}
 				} else if (OSMTracker.Preferences.VAL_OUTPUT_ACCURACY_WPT_CMT.equals(accuracyInfo)) {
 					// Output accuracy in separate tag
-					out.append("\t\t" + "<name>" + CDATA_START + name + CDATA_END + "</name>" + "\n");
+					out.append("\t\t" + "<name>" + CDATA_START).append(name).append(CDATA_END).append("</name>").append("\n");
 					if (OSMTracker.Preferences.VAL_OUTPUT_COMPASS_COMMENT.equals(compass) &&
 							! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))) {
-						out.append("\t\t" + "<cmt>" + CDATA_START + accuracy + ": " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) + meterUnit +
-								"\n\t\t\t compass heading: " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS)) +
-								"deg\n\t\t\t compass accuracy: " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY)) +CDATA_END + "</cmt>" + "\n");
+						out.append("\t\t" + "<cmt>" + CDATA_START).append(accuracy).append(": ").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY))).append(meterUnit).append("\n\t\t\t compass heading: ").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))).append("deg\n\t\t\t compass accuracy: ").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY))).append(CDATA_END).append("</cmt>").append("\n");
 					} else {
-						out.append("\t\t" + "<cmt>" + CDATA_START + accuracy + ": " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) + meterUnit + CDATA_END + "</cmt>" + "\n");
+						out.append("\t\t" + "<cmt>" + CDATA_START).append(accuracy).append(": ").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY))).append(meterUnit).append(CDATA_END).append("</cmt>").append("\n");
 					}
 				} else {
 					// Unknown value for accuracy info, shouldn't occur but who knows ?
 					// See issue #68. Output at least the name just in case.
-					out.append("\t\t" + "<name>" + CDATA_START + name + CDATA_END + "</name>" + "\n");
+					out.append("\t\t" + "<name>" + CDATA_START).append(name).append(CDATA_END).append("</name>").append("\n");
 				}
 			} else {
 				// No accuracy info requested, or available
-				out.append("\t\t" + "<name>" + CDATA_START + name + CDATA_END + "</name>" + "\n");
+				out.append("\t\t" + "<name>" + CDATA_START).append(name).append(CDATA_END).append("</name>").append("\n");
 				if (OSMTracker.Preferences.VAL_OUTPUT_COMPASS_COMMENT.equals(compass) &&
 						! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))) {
-					out.append("\t\t"+ "<cmt>" + CDATA_START + "compass: " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS)) +
-							"\n\t\t\tcompass accuracy: " + c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY)) + CDATA_END + "</cmt>\n");
+					out.append("\t\t" + "<cmt>" + CDATA_START + "compass: ").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))).append("\n\t\t\tcompass accuracy: ").append(c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY))).append(CDATA_END).append("</cmt>\n");
 				}
 			}
 			
 			String link = c.getString(c.getColumnIndex(TrackContentProvider.Schema.COL_LINK));
 			if (link != null) {
-					out.append("\t\t" + "<link href=\"" + URLEncoder.encode(link) + "\">" + "\n");
-					out.append("\t\t\t" + "<text>" + link +"</text>\n");
+					out.append("\t\t" + "<link href=\"").append(URLEncoder.encode(link)).append("\">").append("\n");
+					out.append("\t\t\t" + "<text>").append(link).append("</text>\n");
 					out.append("\t\t" + "</link>" + "\n");
 			}
 			
 			if (! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_NBSATELLITES))) {
-				out.append("\t\t" + "<sat>" + c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_NBSATELLITES)) + "</sat>" + "\n");
+				out.append("\t\t" + "<sat>").append(c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_NBSATELLITES))).append("</sat>").append("\n");
 			}
 
 			if(fillHDOP && ! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY))) {
-				out.append("\t\t" + "<hdop>" + (c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) / OSMTracker.HDOP_APPROXIMATION_FACTOR) + "</hdop>" + "\n");
+				out.append("\t\t" + "<hdop>").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) / OSMTracker.HDOP_APPROXIMATION_FACTOR).append("</hdop>").append("\n");
 			}
 
 			if (OSMTracker.Preferences.VAL_OUTPUT_COMPASS_EXTENSION.equals(compass) &&
 					! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))) {
 				out.append("\t\t<extensions>\n");
-				out.append("\t\t\t"+ "<compass>" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS)) + "</compass>\n");
-				out.append("\t\t\t" + "<compass_accuracy>" + c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY)) + "</compass_accuracy>" + "\n");
+				out.append("\t\t\t" + "<compass>").append(c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))).append("</compass>\n");
+				out.append("\t\t\t" + "<compass_accuracy>").append(c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY))).append("</compass_accuracy>").append("\n");
 				out.append("\t\t</extensions>\n");				
 			}
 			
@@ -518,11 +501,9 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 		// Get the new location where files related to these waypoints are/should be stored		
 		File trackDir = DataHelper.getTrackDirectory(trackId);
 
-		if(trackDir != null){
-			Log.v(TAG, "Copying files from the standard TrackDir ["+trackDir+"] to the export directory ["+gpxOutputDirectory+"]");
-			FileSystemUtils.copyDirectoryContents(gpxOutputDirectory, trackDir);
-		}
-		
+		Log.v(TAG, "Copying files from the standard TrackDir ["+trackDir+"] to the export directory ["+gpxOutputDirectory+"]");
+		FileSystemUtils.copyDirectoryContents(gpxOutputDirectory, trackDir);
+
 	}
 
 	/**

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -44,7 +44,7 @@ import java.util.regex.Pattern;
  * @author Nicolas Guillaumin
  *
  */
-public abstract class ExportTrackTask  extends AsyncTask<Void, Long, Boolean> {
+public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 
 	private static final String TAG = ExportTrackTask.class.getSimpleName();
 

--- a/app/src/main/java/net/osmtracker/osm/UploadToOpenStreetMapTask.java
+++ b/app/src/main/java/net/osmtracker/osm/UploadToOpenStreetMapTask.java
@@ -1,19 +1,19 @@
 package net.osmtracker.osm;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.Charset;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.ProgressDialog;
+import android.content.DialogInterface;
+import android.content.SharedPreferences.Editor;
+import android.os.AsyncTask;
+import android.preference.PreferenceManager;
+import android.util.Log;
 
 import net.osmtracker.OSMTracker;
 import net.osmtracker.R;
 import net.osmtracker.db.DataHelper;
-import net.osmtracker.util.DialogUtils;
 import net.osmtracker.db.model.Track;
-
-import oauth.signpost.commonshttp.CommonsHttpOAuthConsumer;
+import net.osmtracker.util.DialogUtils;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -24,14 +24,14 @@ import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.DefaultHttpClient;
 
-import android.app.Activity;
-import android.app.AlertDialog;
-import android.app.ProgressDialog;
-import android.content.DialogInterface;
-import android.content.SharedPreferences.Editor;
-import android.os.AsyncTask;
-import android.preference.PreferenceManager;
-import android.util.Log;
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+
+import oauth.signpost.commonshttp.CommonsHttpOAuthConsumer;
 
 /**
  * Uploads a GPX file to OpenStreetMap
@@ -131,7 +131,7 @@ public class UploadToOpenStreetMapTask extends AsyncTask<Void, Void, Void> {
 			});
 
 			// API parameters
-			entity.addPart(OpenStreetMapConstants.Api.Gpx.Parameters.FILE, new FileBody(gpxFile, filename, GPX_MIMETYPE, Charset.defaultCharset().name()));
+			entity.addPart(OpenStreetMapConstants.Api.Gpx.Parameters.FILE, new FileBody(gpxFile, filename, DataHelper.MIME_GPX_TYPE, Charset.defaultCharset().name()));
 			entity.addPart(OpenStreetMapConstants.Api.Gpx.Parameters.DESCRIPTION, new StringBody(description, Charset.defaultCharset()));
 			entity.addPart(OpenStreetMapConstants.Api.Gpx.Parameters.TAGS, new StringBody(tags, Charset.defaultCharset()));
 			entity.addPart(OpenStreetMapConstants.Api.Gpx.Parameters.VISIBILITY, new StringBody(visibility.toString().toLowerCase(),Charset.defaultCharset()));

--- a/app/src/main/res/menu/trackmgr_contextmenu.xml
+++ b/app/src/main/res/menu/trackmgr_contextmenu.xml
@@ -18,7 +18,10 @@
         android:title="@string/trackmgr_contextmenu_export" />
     <item
         android:id="@+id/trackmgr_contextmenu_share"
-        android:title="@string/trackmgr_contextmenu_export_and_share" />
+        android:title="@string/trackmgr_contextmenu_share" />
+<!--    <item-->
+<!--        android:id="@+id/trackmgr_contextmenu_export_and_share"-->
+<!--        android:title="@string/trackmgr_contextmenu_export_and_share" />-->
     <item
         android:id="@+id/trackmgr_contextmenu_osm_upload"
         android:title="@string/trackmgr_contextmenu_osm_upload" />

--- a/app/src/main/res/menu/trackmgr_contextmenu.xml
+++ b/app/src/main/res/menu/trackmgr_contextmenu.xml
@@ -14,11 +14,11 @@
         android:id="@+id/trackmgr_contextmenu_details"
         android:title="@string/trackmgr_contextmenu_details" />
     <item
-        android:id="@+id/trackmgr_contextmenu_share"
-        android:title="@string/trackmgr_contextmenu_share" />
-    <item
         android:id="@+id/trackmgr_contextmenu_export"
         android:title="@string/trackmgr_contextmenu_export" />
+    <item
+        android:id="@+id/trackmgr_contextmenu_share"
+        android:title="@string/trackmgr_contextmenu_export_and_share" />
     <item
         android:id="@+id/trackmgr_contextmenu_osm_upload"
         android:title="@string/trackmgr_contextmenu_osm_upload" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
 	<string name="trackmgr_contextmenu_delete">Delete</string>
 	<string name="trackmgr_contextmenu_export">Export as GPX</string>
 	<string name="trackmgr_contextmenu_share">Share track</string>
+	<string name="trackmgr_contextmenu_export_and_share">Export as GPX and share</string>
 	<string name="trackmgr_contextmenu_osm_upload">Upload to OpenStreetMap</string>
 	<string name="trackmgr_contextmenu_display">Display</string>
 	<string name="trackmgr_contextmenu_details">Details</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -149,7 +149,7 @@
 	<string name="various_heading_display">{0}&#176;</string> <!-- parameters: (heading in degrees) -->
 	<string name="various_heading">Wait for heading&#8230;</string>
 	<string name="various_heading_unknown">Heading can\'t be determined</string>
-	<string name="various_export_finished">Export process finished successfully</string>
+	<string name="various_export_finished">Process finished successfully</string>
 	
 
 	<!-- OSM map view -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
 	<string name="trackmgr_contextmenu_resume">Resume tracking</string>
 	<string name="trackmgr_contextmenu_delete">Delete</string>
 	<string name="trackmgr_contextmenu_export">Export as GPX</string>
-	<string name="trackmgr_contextmenu_share">Share track</string>
+	<string name="trackmgr_contextmenu_share">Share GPX</string>
 	<string name="trackmgr_contextmenu_export_and_share">Export as GPX and share</string>
 	<string name="trackmgr_contextmenu_osm_upload">Upload to OpenStreetMap</string>
 	<string name="trackmgr_contextmenu_display">Display</string>

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -9,4 +9,7 @@
     <files-path
         name="files"
         path="." />
+    <cache-path
+        name="cache"
+        path="."/>
 </paths>


### PR DESCRIPTION
Added new functionality to share an exported GPX file to other apps like mail or Telegram.
One option was added to the track management. The new option is named "Export as GPX and share". This commits those 2 steps in a single interaction.
The '"Export as GPX" option still available. This is just to make sure that the track is exported before sharing. This idea was taken from #84.
***
Also this PR fixes a little bug related to date duplication in name that was not taken under consideration. If the user edits the name and this name already has the date in it the app should not add the date again regardless if the name was changed or not. That is fixed now and this was the intention here #232 
***
### Update
**Export and share** is not added.
Now the user can **Share** the file regardless if the this has been Exported or not.


