### PR TITLE
Fix Delete Layout Test

### DIFF
--- a/app/src/androidTest/java/net/osmtracker/layouts/DeleteLayoutTest.java
+++ b/app/src/androidTest/java/net/osmtracker/layouts/DeleteLayoutTest.java
@@ -9,7 +9,6 @@ import net.osmtracker.activity.ButtonsPresets;
 import net.osmtracker.activity.Preferences;
 import net.osmtracker.util.CustomLayoutsUtils;
 
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -34,11 +33,21 @@ import static org.apache.commons.io.FileUtils.deleteDirectory;
 public class DeleteLayoutTest {
 
     @Rule
-    public ActivityTestRule<ButtonsPresets> mRule = new ActivityTestRule<>(ButtonsPresets.class);
+    public ActivityTestRule<ButtonsPresets> mRule = new ActivityTestRule(ButtonsPresets.class) {
+        @Override
+        protected void beforeActivityLaunched() {
+            //Makes sure that only the mock layout exists
+            try {
+                deleteDirectory(getLayoutsDirectory());
+                injectMockLayout(layoutName, ISOLanguageCode);
+
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    };
 
     // Storage permissions are required
-    @Rule
-    public GrantPermissionRule readPermission = GrantPermissionRule.grant(Manifest.permission.READ_EXTERNAL_STORAGE);
     @Rule
     public GrantPermissionRule writePermission = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
 
@@ -55,21 +64,6 @@ public class DeleteLayoutTest {
         String textToMatch = getStringResource(R.string.buttons_presets_delete_positive_confirmation);
         onView(withText(equalToIgnoringCase(textToMatch))).perform(click());
     }
-
-    /**
-     * Makes sure that only the mock layout exists
-     */
-    @BeforeClass
-    public static void setUp(){
-        try {
-            deleteDirectory(getLayoutsDirectory());
-            injectMockLayout(layoutName, ISOLanguageCode);
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
 
     /**
      * Deletes the mock layout and then checks that:


### PR DESCRIPTION
This PR fix the fail when the test is runned for the first time.  The problem is the setup method cannot create the mock layout because is called "before the class", without permissions to write. 
The solution is moving the code from the `setup` method to a `beforeActivityLaunched()` that overrides a method from `ActivityTestRule`, now the "setup code" is runned when the the class is instantiated but before the activity is launched. 