### PR TITLE
Test build gpx filename

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/TrackDetailEditor.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackDetailEditor.java
@@ -112,13 +112,8 @@ public abstract class TrackDetailEditor extends Activity {
 		// Get default track name
         String defaultDate = DataHelper.FILENAME_FORMATTER.format(startDate);
 
-        // If no changes were made don't append the date
-		if ((enteredName.length() > 0 && !enteredName.equals(tname))) {
-			// Append date to avoid duplicated tracks names only if is not included already
-			if(!enteredName.contains(defaultDate)) enteredName += "_" + defaultDate;
-			values.put(TrackContentProvider.Schema.COL_NAME, enteredName);
-		}
-		
+        values.put(TrackContentProvider.Schema.COL_NAME, enteredName);
+
 		// All other values updated even if empty
 		values.put(TrackContentProvider.Schema.COL_DESCRIPTION, etDescription.getText().toString().trim());
 		values.put(TrackContentProvider.Schema.COL_TAGS, etTags.getText().toString().trim());

--- a/app/src/main/java/net/osmtracker/activity/TrackDetailEditor.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackDetailEditor.java
@@ -107,12 +107,10 @@ public abstract class TrackDetailEditor extends Activity {
 
 		// Save name field, if changed, to db.
 		// String class required for equals to work, and for trim().
-		String enteredName = etName.getText().toString().trim();
-
-		// Get default track name
-        String defaultDate = DataHelper.FILENAME_FORMATTER.format(startDate);
-
-        values.put(TrackContentProvider.Schema.COL_NAME, enteredName);
+		String nameToSave = etName.getText().toString().trim();
+		if(nameToSave.length() == 0)
+			nameToSave = DataHelper.FILENAME_FORMATTER.format(startDate); // Set default track name
+        values.put(TrackContentProvider.Schema.COL_NAME, nameToSave);
 
 		// All other values updated even if empty
 		values.put(TrackContentProvider.Schema.COL_DESCRIPTION, etDescription.getText().toString().trim());

--- a/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
@@ -36,10 +36,9 @@ public class ExportToStorageTask extends ExportTrackTask {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
 
         String trackName = getSanitizedTrackNameByStartDate(startDate);
-        File baseExportDir = getBaseExportDirectory(preferences);
         boolean shouldCreateDirectoryPerTrack = shouldCreateDirectoryPerTrack(preferences);
+        File finalExportDirectory = getBaseExportDirectory(preferences);
 
-        File finalExportDirectory = baseExportDir;
         if( shouldCreateDirectoryPerTrack && trackName.length() >= 1){
             String uniqueFolderName = getUniqueChildNameFor(finalExportDirectory, trackName, "");
             finalExportDirectory = new File(finalExportDirectory, uniqueFolderName);

--- a/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
@@ -28,7 +28,7 @@ public class ExportToStorageTask extends ExportTrackTask {
 
 	public ExportToStorageTask(Context context, long... trackId) {
 		super(context, trackId);
-		ERROR_MESSAGE = context.getResources().getString(R.string.error_create_track_dir);
+		ERROR_MESSAGE = context.getString(R.string.error_create_track_dir);
 	}
 
 	@Override
@@ -52,7 +52,7 @@ public class ExportToStorageTask extends ExportTrackTask {
 	}
 
 
-    String getSanitizedTrackNameByStartDate(Date startDate){
+    public String getSanitizedTrackNameByStartDate(Date startDate){
 
         // Get the name of the track with the received start date
         String selection = TrackContentProvider.Schema.COL_START_DATE + " = ?";
@@ -70,14 +70,14 @@ public class ExportToStorageTask extends ExportTrackTask {
         return trackName;
     }
 
-    boolean shouldCreateDirectoryPerTrack(SharedPreferences prefs){
+    public boolean shouldCreateDirectoryPerTrack(SharedPreferences prefs){
 	    return prefs.getBoolean(OSMTracker.Preferences.KEY_OUTPUT_DIR_PER_TRACK,
                 OSMTracker.Preferences.VAL_OUTPUT_GPX_OUTPUT_DIR_PER_TRACK);
 
     }
 
     // Create before returning if not exists
-    File getBaseExportDirectory(SharedPreferences prefs){
+    public File getBaseExportDirectory(SharedPreferences prefs){
         File rootStorageDirectory = Environment.getExternalStorageDirectory();
 
         String exportDirectoryNameInPreferences = prefs.getString(

--- a/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
@@ -5,7 +5,6 @@ import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.os.Environment;
 import android.preference.PreferenceManager;
-import android.util.Log;
 
 import net.osmtracker.OSMTracker;
 import net.osmtracker.R;
@@ -15,6 +14,8 @@ import net.osmtracker.exception.ExportTrackException;
 import java.io.File;
 import java.util.Date;
 
+import static net.osmtracker.util.FileSystemUtils.getUniqueChildNameFor;
+
 /**
  * Exports to the external storage / SD card
  * in a folder defined by the user.
@@ -22,79 +23,72 @@ import java.util.Date;
 public class ExportToStorageTask extends ExportTrackTask {
 
 	private static final String TAG = ExportToStorageTask.class.getSimpleName();
+	private String ERROR_MESSAGE;
+
 
 	public ExportToStorageTask(Context context, long... trackId) {
 		super(context, trackId);
+		ERROR_MESSAGE = context.getResources().getString(R.string.error_create_track_dir);
 	}
 
 	@Override
 	protected File getExportDirectory(Date startDate) throws ExportTrackException {
-		File sdRoot = Environment.getExternalStorageDirectory();
-		
-		// The location that the user has specified gpx files 
-		// and associated content to be written
-		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-		String userGPXExportDirectoryName = prefs.getString(
-				OSMTracker.Preferences.KEY_STORAGE_DIR,	OSMTracker.Preferences.VAL_STORAGE_DIR);
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
 
-		boolean directoryPerTrack = prefs.getBoolean(OSMTracker.Preferences.KEY_OUTPUT_DIR_PER_TRACK, 
-				OSMTracker.Preferences.VAL_OUTPUT_GPX_OUTPUT_DIR_PER_TRACK);
-				
-		// Create the path to the directory to which we will be writing
-		// Trim the directory name, as additional spaces at the end will 
-		// not allow the directory to be created if required
-		String exportDirectoryPath = userGPXExportDirectoryName.trim();
-		String perTrackDirectory = "";
+        String trackName = getSanitizedTrackNameByStartDate(startDate);
+        File baseExportDir = getBaseExportDirectory(preferences);
+        boolean shouldCreateDirectoryPerTrack = shouldCreateDirectoryPerTrack(preferences);
 
-		if (directoryPerTrack) {
+        File finalExportDirectory = baseExportDir;
+        if( shouldCreateDirectoryPerTrack && trackName.length() >= 1){
+            String uniqueFolderName = getUniqueChildNameFor(finalExportDirectory, trackName, "");
+            finalExportDirectory = new File(finalExportDirectory, uniqueFolderName);
+            finalExportDirectory.mkdirs();
+        }
+        if(! finalExportDirectory.exists() )
+            throw new ExportTrackException(ERROR_MESSAGE);
 
-			String trackName = "";
+        return finalExportDirectory;
+	}
 
-			// Get the name of the track with the received start date
-			String selection = TrackContentProvider.Schema.COL_START_DATE + " = ?";
-			String[] args = {String.valueOf(startDate.getTime())};
 
-			Cursor c = context.getContentResolver().query(
-					TrackContentProvider.CONTENT_URI_TRACK, null, selection, args, null);
-			
-			if(c != null && c.moveToFirst()){
-				int i = c.getColumnIndex(TrackContentProvider.Schema.COL_NAME);
-				trackName = c.getString(i);
-			}
-			if(trackName != null && trackName.length() >= 1) {
-				trackName = trackName.replace("/", "_");
-				perTrackDirectory = File.separator + trackName.trim();
-			}
+    String getSanitizedTrackNameByStartDate(Date startDate){
 
-		}
-		
-		// Create a file based on the path we've generated above
-		File trackGPXExportDirectory = new File(sdRoot + exportDirectoryPath + perTrackDirectory);
+        // Get the name of the track with the received start date
+        String selection = TrackContentProvider.Schema.COL_START_DATE + " = ?";
+        String[] args = {String.valueOf(startDate.getTime())};
+        Cursor cursor = context.getContentResolver().query(
+                TrackContentProvider.CONTENT_URI_TRACK, null, selection, args, null);
 
-		// Create track directory if needed
-		if (! trackGPXExportDirectory.exists()) {
-			if (! trackGPXExportDirectory.mkdirs()) {
-				Log.w(TAG,"Failed to create directory [" 
-						+trackGPXExportDirectory.getAbsolutePath()+ "]");
-			}
-			
-			if (! trackGPXExportDirectory.exists()) {
-				// Specific hack for Google Nexus  S(See issue #168)
-				if (android.os.Build.MODEL.equals(OSMTracker.Devices.NEXUS_S)) {
-					// exportDirectoryPath always starts with "/"
-					trackGPXExportDirectory = new File(exportDirectoryPath + perTrackDirectory);
-					trackGPXExportDirectory.mkdirs();
-				}
-			}
-			
-			if (! trackGPXExportDirectory.exists()) {
-				throw new ExportTrackException(context.getResources().getString(R.string.error_create_track_dir,
-						trackGPXExportDirectory.getAbsolutePath()));
-			}
-		}
+        String trackName = "";
+        if(cursor != null && cursor.moveToFirst()){
+            trackName = cursor.getString(cursor.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
+        }
+        if(trackName != null && trackName.length() >= 1) {
+            trackName = trackName.replace("/", "_").trim();
+        }
+        return trackName;
+    }
 
-		return trackGPXExportDirectory;
-	}	
+    boolean shouldCreateDirectoryPerTrack(SharedPreferences prefs){
+	    return prefs.getBoolean(OSMTracker.Preferences.KEY_OUTPUT_DIR_PER_TRACK,
+                OSMTracker.Preferences.VAL_OUTPUT_GPX_OUTPUT_DIR_PER_TRACK);
+
+    }
+
+    // Create before returning if not exists
+    File getBaseExportDirectory(SharedPreferences prefs){
+        File rootStorageDirectory = Environment.getExternalStorageDirectory();
+
+        String exportDirectoryNameInPreferences = prefs.getString(
+                OSMTracker.Preferences.KEY_STORAGE_DIR,	OSMTracker.Preferences.VAL_STORAGE_DIR);
+
+        File baseExportDirectory = new File(rootStorageDirectory, exportDirectoryNameInPreferences);
+        if(! baseExportDirectory.exists()){
+            baseExportDirectory.mkdirs();
+        }
+        return baseExportDirectory;
+    }
 
 	@Override
 	protected boolean exportMediaFiles() {

--- a/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
@@ -39,7 +39,7 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 	}
 
 	@Override
-	protected String buildGPXFilename(Cursor c) {
+	public String buildGPXFilename(Cursor c) {
 		filename = super.buildGPXFilename(c);
 		return tmpFile.getName();
 	}

--- a/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
@@ -39,8 +39,8 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 	}
 
 	@Override
-	public String buildGPXFilename(Cursor c) {
-		filename = super.buildGPXFilename(c);
+	public String buildGPXFilename(Cursor c, File parentDirectory) {
+		filename = super.buildGPXFilename(c, parentDirectory);
 		return tmpFile.getName();
 	}
 

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -551,28 +551,61 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 	 * @param c  Track info: {@link TrackContentProvider.Schema#COL_NAME}, {@link TrackContentProvider.Schema#COL_START_DATE}
 	 * @return  GPX filename, not including the path
 	 */
-	protected String buildGPXFilename(Cursor c) {
-		// Build GPX filename from track info & preferences
-		final String filenameOutput = PreferenceManager.getDefaultSharedPreferences(context).getString(
+//	public String buildGPXFilename(Cursor c) {
+//		// Build GPX filename from track info & preferences
+//		final String filenameOutput = PreferenceManager.getDefaultSharedPreferences(context).getString(
+//				OSMTracker.Preferences.KEY_OUTPUT_FILENAME,
+//				OSMTracker.Preferences.VAL_OUTPUT_FILENAME);
+//
+//		StringBuilder filenameBase = new StringBuilder();
+//		final int colName = c.getColumnIndexOrThrow(TrackContentProvider.Schema.COL_NAME);
+//
+//		String tname = c.getString(colName);
+//
+//		if ((! c.isNull(colName))
+//				&& (! filenameOutput.equals(OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE))) {
+//
+//			final String tname_raw = tname.trim().replace(':', ';');
+//			final String sanitized = FILENAME_CHARS_BLACKLIST_PATTERN.matcher(tname_raw).replaceAll("_");
+//
+//			filenameBase.append(sanitized);
+//		}
+//
+//		filenameBase.append(DataHelper.EXTENSION_GPX);
+//		return filenameBase.toString();
+//	}
+
+	public String buildGPXFilename(Cursor cursor) {
+		String trackName =  cursor.getString(cursor.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
+		trackName = sanitizeTrackName(trackName);
+
+		String desiredOutputFormat = PreferenceManager.getDefaultSharedPreferences(context).getString(
 				OSMTracker.Preferences.KEY_OUTPUT_FILENAME,
 				OSMTracker.Preferences.VAL_OUTPUT_FILENAME);
 
-		StringBuilder filenameBase = new StringBuilder();
-		final int colName = c.getColumnIndexOrThrow(TrackContentProvider.Schema.COL_NAME);
+		long trackStartDate = cursor.getLong(cursor.getColumnIndex(TrackContentProvider.Schema.COL_START_DATE));
+		String formattedTrackStartDate = DataHelper.FILENAME_FORMATTER.format(new Date(trackStartDate));
 
-		String tname = c.getString(colName);
-
-		if ((! c.isNull(colName))
-				&& (! filenameOutput.equals(OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE))) {
-
-			final String tname_raw = tname.trim().replace(':', ';');
-			final String sanitized = FILENAME_CHARS_BLACKLIST_PATTERN.matcher(tname_raw).replaceAll("_");
-
-			filenameBase.append(sanitized);
+		String finalGpxFilename = "";
+		switch(desiredOutputFormat){
+			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME:
+				finalGpxFilename += trackName;
+				break;
+			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME_DATE:
+				finalGpxFilename += trackName + "_" + formattedTrackStartDate;
+				break;
+			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE:
+				finalGpxFilename += formattedTrackStartDate;
+				break;
 		}
+		return finalGpxFilename + DataHelper.EXTENSION_GPX;
+	}
 
-		filenameBase.append(DataHelper.EXTENSION_GPX);
-		return filenameBase.toString();
+
+	public String sanitizeTrackName(String trackName){
+		String first = trackName.trim().replace(':', ';');
+		String second = FILENAME_CHARS_BLACKLIST_PATTERN.matcher(first).replaceAll("_");
+		return second;
 	}
 
 }

--- a/app/src/main/java/net/osmtracker/util/FileSystemUtils.java
+++ b/app/src/main/java/net/osmtracker/util/FileSystemUtils.java
@@ -179,5 +179,27 @@ public final class FileSystemUtils {
 
 		return deleted;		
 	}
-	
+
+
+	/**
+	 * Return an unique name for a child in the parent Directory
+	 * If there's a child in the parent with the received name + extension then will return name{i} + extension
+	 * extension can be "" for folders or a real extension (like ".gpx") for files and {i} would be a serial number
+	 */
+	public static String getUniqueChildNameFor(File parentDirectory, String childName, String childExtension) {
+		int serial = 0;
+		String suffix = "";
+		String currentName;
+		File testFile;
+		do{
+			currentName = childName + suffix + childExtension;
+			testFile = new File(parentDirectory, currentName);
+			serial++;
+			suffix = "" + serial;
+
+		}while(testFile.exists());
+
+		return currentName;
+	}
+
 }

--- a/app/src/test/java/net/osmtracker/gpx/ExportTrackTest.java
+++ b/app/src/test/java/net/osmtracker/gpx/ExportTrackTest.java
@@ -1,4 +1,4 @@
-package net.osmtracker.gpx.export;
+package net.osmtracker.gpx;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -24,13 +24,13 @@ import static net.osmtracker.OSMTracker.Preferences;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ PreferenceManager.class })
-public class BuildGPXFilenameTest {
+public class ExportTrackTest {
 
     ExportToStorageTask task;
     Context mockContext = Mockito.mock(Context.class);
 
     @Test
-    public void testBuildGPXFilenameUsingOnlyTrackName(){
+    public void testBuildGPXFilenameUsingOnlyTrackName() {
         // Method parameters
         String trackNameInDatabase = "MyTrack";
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
@@ -43,7 +43,7 @@ public class BuildGPXFilenameTest {
     }
 
     @Test
-    public void testBuildGPXFilenameUsingTrackNameAndStartDate(){
+    public void testBuildGPXFilenameUsingTrackNameAndStartDate() {
         // Method parameters
         String trackNameInDatabase = "MyTrack";
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
@@ -55,7 +55,7 @@ public class BuildGPXFilenameTest {
     }
 
     @Test
-    public void testBuildGPXFilenameUsingOnlyStartDate(){
+    public void testBuildGPXFilenameUsingOnlyStartDate() {
         // Method parameters
         String trackNameInDatabase = "MyTrack";
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
@@ -67,7 +67,7 @@ public class BuildGPXFilenameTest {
     }
 
     @Test
-    public void testBuildGPXFilenameWhenSanitizesTrackName(){
+    public void testBuildGPXFilenameWhenSanitizesTrackName() {
         // Method parameters
         String trackNameInDatabase = ":M/y*T@r~a\\c?k:";
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
@@ -78,8 +78,32 @@ public class BuildGPXFilenameTest {
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
 
+    @Test
+    public void testBuildGPXFilenameWhenUsesTrackNameButThereIsNoName() {
+        // Method parameters
+        String trackNameInDatabase = "";
+        Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
+        String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-    void doTestBuildGPXFilename(String trackName, String desiredFormat, long trackStartDate, String expectedFilename){
+        String expectedFilename = "2000-01-02_03-04-05.gpx"; // Must fallback to use the start date
+
+        doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
+    }
+
+    @Test
+    public void testBuildGPXFilenameWhenUsesTrackNameAndStartDateButThereIsNoName() {
+        // Method parameters
+        String trackNameInDatabase = "";
+        Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
+        String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME_DATE;
+
+        String expectedFilename = "2000-01-02_03-04-05.gpx"; // Must fallback to use the start date
+
+        doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
+    }
+
+
+    void doTestBuildGPXFilename(String trackName, String desiredFormat, long trackStartDate, String expectedFilename) {
         setupPreferencesToReturn(desiredFormat);
 
         task = new ExportToStorageTask(mockContext, 3);
@@ -91,7 +115,7 @@ public class BuildGPXFilenameTest {
 
 
     // Used for testing buildGPXFilename
-    void setupPreferencesToReturn( String desiredFormat ){
+    void setupPreferencesToReturn(String desiredFormat) {
         // Mock preferences
         SharedPreferences mockPrefs = mock(SharedPreferences.class);
         when(mockPrefs.getString(KEY_OUTPUT_FILENAME, VAL_OUTPUT_FILENAME)).thenReturn(desiredFormat);
@@ -100,6 +124,7 @@ public class BuildGPXFilenameTest {
 
         when(PreferenceManager.getDefaultSharedPreferences(mockContext)).thenReturn(mockPrefs);
     }
+
 
     // Used for testing buildGPXFilename
     Cursor createMockCursor(String trackName, long trackStartDate){

--- a/app/src/test/java/net/osmtracker/gpx/ExportTrackTest.java
+++ b/app/src/test/java/net/osmtracker/gpx/ExportTrackTest.java
@@ -4,12 +4,21 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.preference.PreferenceManager;
+
+import net.osmtracker.R;
 import net.osmtracker.gpx.ExportToStorageTask;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileAttribute;
 import java.util.Date;
 
 import static junit.framework.TestCase.assertEquals;
@@ -26,8 +35,12 @@ import static net.osmtracker.OSMTracker.Preferences;
 @PrepareForTest({ PreferenceManager.class })
 public class ExportTrackTest {
 
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     ExportToStorageTask task;
     Context mockContext = Mockito.mock(Context.class);
+
 
     @Test
     public void testBuildGPXFilenameUsingOnlyTrackName() {
@@ -106,9 +119,11 @@ public class ExportTrackTest {
     void doTestBuildGPXFilename(String trackName, String desiredFormat, long trackStartDate, String expectedFilename) {
         setupPreferencesToReturn(desiredFormat);
 
+        when(mockContext.getString(R.string.error_create_track_dir)).thenReturn("Any");
+
         task = new ExportToStorageTask(mockContext, 3);
 
-        String result = task.buildGPXFilename(createMockCursor(trackName, trackStartDate));
+        String result = task.buildGPXFilename(createMockCursor(trackName, trackStartDate), temporaryFolder.getRoot());
 
         assertEquals(expectedFilename, result);
     }

--- a/app/src/test/java/net/osmtracker/gpx/ExportTrackTest.java
+++ b/app/src/test/java/net/osmtracker/gpx/ExportTrackTest.java
@@ -6,7 +6,6 @@ import android.database.Cursor;
 import android.preference.PreferenceManager;
 
 import net.osmtracker.R;
-import net.osmtracker.gpx.ExportToStorageTask;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,9 +15,6 @@ import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.io.File;
-import java.nio.file.Files;
-import java.nio.file.attribute.FileAttribute;
 import java.util.Date;
 
 import static junit.framework.TestCase.assertEquals;

--- a/app/src/test/java/net/osmtracker/gpx/export/BuildGPXFilenameTest.java
+++ b/app/src/test/java/net/osmtracker/gpx/export/BuildGPXFilenameTest.java
@@ -1,0 +1,119 @@
+package net.osmtracker.gpx.export;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.database.Cursor;
+import android.preference.PreferenceManager;
+import net.osmtracker.gpx.ExportToStorageTask;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import java.util.Date;
+
+import static junit.framework.TestCase.assertEquals;
+import static net.osmtracker.db.TrackContentProvider.Schema;
+import static net.osmtracker.OSMTracker.Preferences.KEY_OUTPUT_FILENAME;
+import static net.osmtracker.OSMTracker.Preferences.VAL_OUTPUT_FILENAME;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static net.osmtracker.util.UnitTestUtils.createDateFrom;
+import static net.osmtracker.OSMTracker.Preferences;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ PreferenceManager.class })
+public class BuildGPXFilenameTest {
+
+    ExportToStorageTask task;
+    Context mockContext = Mockito.mock(Context.class);
+
+    @Test
+    public void testBuildGPXFilenameUsingOnlyTrackName(){
+        // Method parameters
+        String trackNameInDatabase = "MyTrack";
+        Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
+        String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
+
+        String expectedFilename = "MyTrack.gpx";
+
+        doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
+
+    }
+
+    @Test
+    public void testBuildGPXFilenameUsingTrackNameAndStartDate(){
+        // Method parameters
+        String trackNameInDatabase = "MyTrack";
+        Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
+        String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME_DATE;
+
+        String expectedFilename = "MyTrack_2000-01-02_03-04-05.gpx";
+
+        doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
+    }
+
+    @Test
+    public void testBuildGPXFilenameUsingOnlyStartDate(){
+        // Method parameters
+        String trackNameInDatabase = "MyTrack";
+        Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
+        String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_DATE;
+
+        String expectedFilename = "2000-01-02_03-04-05.gpx";
+
+        doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
+    }
+
+    @Test
+    public void testBuildGPXFilenameWhenSanitizesTrackName(){
+        // Method parameters
+        String trackNameInDatabase = ":M/y*T@r~a\\c?k:";
+        Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
+        String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
+
+        String expectedFilename = ";M_y_T_r_a_c_k;.gpx";
+
+        doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
+    }
+
+
+    void doTestBuildGPXFilename(String trackName, String desiredFormat, long trackStartDate, String expectedFilename){
+        setupPreferencesToReturn(desiredFormat);
+
+        task = new ExportToStorageTask(mockContext, 3);
+
+        String result = task.buildGPXFilename(createMockCursor(trackName, trackStartDate));
+
+        assertEquals(expectedFilename, result);
+    }
+
+
+    // Used for testing buildGPXFilename
+    void setupPreferencesToReturn( String desiredFormat ){
+        // Mock preferences
+        SharedPreferences mockPrefs = mock(SharedPreferences.class);
+        when(mockPrefs.getString(KEY_OUTPUT_FILENAME, VAL_OUTPUT_FILENAME)).thenReturn(desiredFormat);
+
+        mockStatic(PreferenceManager.class);
+
+        when(PreferenceManager.getDefaultSharedPreferences(mockContext)).thenReturn(mockPrefs);
+    }
+
+    // Used for testing buildGPXFilename
+    Cursor createMockCursor(String trackName, long trackStartDate){
+        Cursor mockCursor = Mockito.mock(Cursor.class);
+        when(mockCursor.getColumnIndex(Schema.COL_NAME)).thenReturn(1);
+        when(mockCursor.getString(1)).thenReturn(trackName);
+
+        when(mockCursor.getColumnIndex(Schema.COL_START_DATE)).thenReturn(2);
+        when(mockCursor.getLong(2)).thenReturn(trackStartDate);
+
+        return mockCursor;
+
+    }
+
+
+
+}

--- a/app/src/test/java/net/osmtracker/util/UnitTestUtils.java
+++ b/app/src/test/java/net/osmtracker/util/UnitTestUtils.java
@@ -4,6 +4,8 @@ import android.content.SharedPreferences;
 
 import net.osmtracker.OSMTracker;
 
+import java.util.Date;
+
 import static org.powermock.api.mockito.PowerMockito.when;
 
 public class UnitTestUtils {
@@ -38,4 +40,9 @@ public class UnitTestUtils {
                 OSMTracker.Preferences.VAL_BRANCH_NAME);
     }
 
+    // This method is used to hide the weird modifications (offsets) that need to be made when creating a Date object
+    // See why here https://docs.oracle.com/javase/8/docs/api/java/util/Date.html#setYear-int-
+    public static Date createDateFrom(int year, int month, int day, int hour, int minute, int second) {
+        return new Date(year-1900, month-1, day, hour, minute, second);
+    }
 }


### PR DESCRIPTION
- Doesn't append the start date to the track's name after editing
- Validate duplicated files and directories when exporting 
- Follow the output gpx format specified in preferences 
- Add unit tests for the gpx filename building
- Add utility method for encapsulating Date objects building (weird modifications need to be made)
- Split some too long methods into smaller ones 