### PR TITLE
Targetsdk update 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ jdk: oraclejdk8
 
 android:
     components:
-        - build-tools-28.0.3
-        - android-28
+        - build-tools-29.0.2
+        - android-29
         - tools
-        - android-21
-        - sys-img-armeabi-v7a-android-21
+        - android-22
+        - sys-img-armeabi-v7a-android-22
 
 licenses:
     - android-sdk-license-.+
@@ -20,7 +20,7 @@ before_install:
 - yes | sdkmanager "platforms;android-27"
 
 before_script:
-     - echo no | android create avd --force -n test -c 100M -t android-21 --abi armeabi-v7a
+     - echo no | android create avd --force -n test -c 100M -t android-22 --abi armeabi-v7a
      - emulator -avd test -no-audio -no-window &
      - android-wait-for-emulator
      - adb shell input keyevent 82 &

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,13 +5,13 @@ apply plugin: 'kotlin-android-extensions'
 android {
 
     useLibrary 'org.apache.http.legacy'
-    compileSdkVersion 28
-    buildToolsVersion = '28.0.3'
+    compileSdkVersion 29
+    buildToolsVersion = '29.0.2'
 
     defaultConfig {
         applicationId "net.osmtracker"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
         multiDexEnabled true
 
         testApplicationId "net.osmtracker.test"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,6 +60,7 @@ android {
 
     testOptions {
         unitTests.returnDefaultValues = true
+        animationsDisabled = true
     }
 
 }

--- a/app/src/androidTest/java/net/osmtracker/layouts/DownloadLayoutTest.java
+++ b/app/src/androidTest/java/net/osmtracker/layouts/DownloadLayoutTest.java
@@ -34,7 +34,7 @@ public class DownloadLayoutTest {
 
         TestUtils.setLayoutsTestingRepository();
 
-        String layoutName = "ABC";
+        String layoutName = "abc";
 
         navigateToAvailableLayouts();
 

--- a/app/src/androidTest/java/net/osmtracker/layouts/RepositorySettingsDialogTest.java
+++ b/app/src/androidTest/java/net/osmtracker/layouts/RepositorySettingsDialogTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.clearText;
 import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static android.support.test.espresso.action.ViewActions.typeText;
 import static android.support.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
@@ -70,9 +71,9 @@ public class RepositorySettingsDialogTest {
 
         onView(withId(R.id.custom_server)).perform(click());
 
-        onView(withId(R.id.github_username)).perform(clearText(), typeText(user));
-        onView(withId(R.id.repository_name)).perform(clearText(), typeText(repo));
-        onView(withId(R.id.branch_name)).perform(clearText(), typeText(branch));
+        onView(withId(R.id.github_username)).perform(clearText(), typeText(user), closeSoftKeyboard());
+        onView(withId(R.id.repository_name)).perform(clearText(), typeText(repo), closeSoftKeyboard());
+        onView(withId(R.id.branch_name)).perform(clearText(), typeText(branch), closeSoftKeyboard());
 
         // This is required to find the "Save" button that will be clicked next, that button may be
         // invisible because it's covered by the keyboard on small screens

--- a/app/src/androidTest/java/net/osmtracker/layouts/RepositorySettingsDialogTest.java
+++ b/app/src/androidTest/java/net/osmtracker/layouts/RepositorySettingsDialogTest.java
@@ -37,12 +37,12 @@ public class RepositorySettingsDialogTest {
     public void testToggleBehaviour(){
         onView(withId(R.id.github_config)).perform(click());
 
-        onView(withId(R.id.default_server)).perform(click());
+        onView(withId(R.id.default_server)).perform(click(), closeSoftKeyboard());
         checkStateAfterToggle(R.id.default_server, R.id.custom_server);
         checkTextFieldsState(not(isEnabled()));
         checkTextFieldsDefaultValues();
 
-        onView(withId(R.id.custom_server)).perform(click());
+        onView(withId(R.id.custom_server)).perform(click(), closeSoftKeyboard());
         checkStateAfterToggle(R.id.custom_server, R.id.default_server);
         checkTextFieldsState(isEnabled());
     }
@@ -69,15 +69,11 @@ public class RepositorySettingsDialogTest {
     public void checkRepositoryValidity(String user, String repo, String branch, boolean isValid){
         onView(withId(R.id.github_config)).perform(click());
 
-        onView(withId(R.id.custom_server)).perform(click());
+        onView(withId(R.id.custom_server)).perform(click(), closeSoftKeyboard());
 
         onView(withId(R.id.github_username)).perform(clearText(), typeText(user), closeSoftKeyboard());
         onView(withId(R.id.repository_name)).perform(clearText(), typeText(repo), closeSoftKeyboard());
         onView(withId(R.id.branch_name)).perform(clearText(), typeText(branch), closeSoftKeyboard());
-
-        // This is required to find the "Save" button that will be clicked next, that button may be
-        // invisible because it's covered by the keyboard on small screens
-        Espresso.closeSoftKeyboard();
 
         onView(withText(getStringResource(R.string.menu_save))).perform(click());
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,11 +15,13 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
+    <!-- FIXME: requestLegacyExternalStorage will be disabled on android 11 -->
     <application
         android:description="@string/app_description"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/HighContrast">
+        android:theme="@style/HighContrast"
+        android:requestLegacyExternalStorage="true">
 
         <uses-library
             android:name="org.apache.http.legacy"


### PR DESCRIPTION
This PR upgrades to target Android 10 (API level 29) to fulfill Google Play requirements.  Android version on Travis tests were upgraded too, with some fixes on instrumentation tests due to this changes. Finally, disable scoped storage (see issue #259)
