### PR TITLE
Simplification of GPX files export (creation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ app/null/
 
 # python vitualenv
 .venv
+
+# GPX created during tests
+app/src/test/assets/gpx/output-test.gpx

--- a/app/src/main/java/net/osmtracker/activity/TrackDetailEditor.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackDetailEditor.java
@@ -66,7 +66,7 @@ public abstract class TrackDetailEditor extends Activity {
 	
 	protected void bindTrack(Track t) {
 		if (etName.length() == 0) {
-			etName.setText(t.getName());
+			etName.setText(t.getDisplayName());
 		}
 
 		etDescription.setText(t.getDescription());

--- a/app/src/main/java/net/osmtracker/db/TrackContentProvider.java
+++ b/app/src/main/java/net/osmtracker/db/TrackContentProvider.java
@@ -44,8 +44,18 @@ public class TrackContentProvider extends ContentProvider {
 	/**
 	 * Uri for a specific waypoint
 	 */
+	public static final Uri CONTENT_URI_WAYPOINT = Uri.parse("content://" + AUTHORITY + "/" + Schema.TBL_WAYPOINT);
+
+	/**
+	 * Uri for a specific waypoint by uuid
+	 */
 	public static final Uri CONTENT_URI_WAYPOINT_UUID = Uri.parse("content://" + AUTHORITY + "/" + Schema.TBL_WAYPOINT + "/uuid");
-	
+
+	/**
+	 * Uri for a specific trackpoint
+	 */
+	public static final Uri CONTENT_URI_TRACKPOINT = Uri.parse("content://" + AUTHORITY + "/" + Schema.TBL_TRACKPOINT);
+
 	/**
 	 * tables and joins to be used within a query to get the important informations of a track
 	 */
@@ -68,7 +78,7 @@ public class TrackContentProvider extends ContentProvider {
 		"count(" + Schema.TBL_TRACKPOINT + "." + Schema.COL_ID + ") as " + Schema.COL_TRACKPOINT_COUNT,
 		"(SELECT count("+Schema.TBL_WAYPOINT+"."+Schema.COL_TRACK_ID+") FROM "+Schema.TBL_WAYPOINT+" WHERE "+Schema.TBL_WAYPOINT+"."+Schema.COL_TRACK_ID+" = " + Schema.TBL_TRACK + "." + Schema.COL_ID + ") as " + Schema.COL_WAYPOINT_COUNT
 	};
-	
+
 	/**
 	 * the group by statement that is used for the track statements
 	 */
@@ -88,7 +98,9 @@ public class TrackContentProvider extends ContentProvider {
 		uriMatcher.addURI(AUTHORITY, Schema.TBL_TRACK + "/#/end", Schema.URI_CODE_TRACK_END);
 		uriMatcher.addURI(AUTHORITY, Schema.TBL_TRACK + "/#/" + Schema.TBL_WAYPOINT + "s", Schema.URI_CODE_TRACK_WAYPOINTS);
 		uriMatcher.addURI(AUTHORITY, Schema.TBL_TRACK + "/#/" + Schema.TBL_TRACKPOINT + "s", Schema.URI_CODE_TRACK_TRACKPOINTS);
+		uriMatcher.addURI(AUTHORITY, Schema.TBL_WAYPOINT + "/#", Schema.URI_CODE_WAYPOINT_ID);
 		uriMatcher.addURI(AUTHORITY, Schema.TBL_WAYPOINT + "/uuid/*", Schema.URI_CODE_WAYPOINT_UUID);
+		uriMatcher.addURI(AUTHORITY, Schema.TBL_TRACKPOINT + "/#", Schema.URI_CODE_TRACKPOINT_ID);
 		
 	}
 	
@@ -101,6 +113,14 @@ public class TrackContentProvider extends ContentProvider {
 				ContentUris.withAppendedId(CONTENT_URI_TRACK, trackId),
 				Schema.TBL_WAYPOINT + "s" );
 	}
+
+	/**
+	 * @param waypointId target waypoint id
+	 * @return Uri for the waypoint
+	 */
+	public static final Uri waypointUri(long waypointId) {
+		return ContentUris.withAppendedId(CONTENT_URI_WAYPOINT, waypointId);
+	}
 	
 	/**
 	 * @param trackId target track id
@@ -110,6 +130,14 @@ public class TrackContentProvider extends ContentProvider {
 		return Uri.withAppendedPath(
 				ContentUris.withAppendedId(CONTENT_URI_TRACK, trackId),
 				Schema.TBL_TRACKPOINT + "s" );		
+	}
+
+	/**
+	 * @param trackpointId target trackpoint id
+	 * @return Uri for the trackpoint
+	 */
+	public static final Uri trackpointUri(long trackpointId) {
+		return ContentUris.withAppendedId(CONTENT_URI_TRACKPOINT, trackpointId);
 	}
 
 	/**
@@ -357,6 +385,26 @@ public class TrackContentProvider extends ContentProvider {
 			selection = Schema.COL_ACTIVE + " = ?";
 			selectionArgs = new String[] {Integer.toString(Schema.VAL_TRACK_ACTIVE)};			
 			break;
+		case Schema.URI_CODE_WAYPOINT_ID:
+			if (selectionIn != null || selectionArgsIn != null) {
+				// Any selection/selectionArgs will be ignored
+				throw new UnsupportedOperationException();
+			}
+			String wayPointId = uri.getLastPathSegment();
+			qb.setTables(Schema.TBL_WAYPOINT);
+			selection = Schema.TBL_WAYPOINT + "." + Schema.COL_ID + " = ?";
+			selectionArgs = new String[] {wayPointId};
+			break;
+		case Schema.URI_CODE_TRACKPOINT_ID:
+			if (selectionIn != null || selectionArgsIn != null) {
+				// Any selection/selectionArgs will be ignored
+				throw new UnsupportedOperationException();
+			}
+			String trackPointId = uri.getLastPathSegment();
+			qb.setTables(Schema.TBL_TRACKPOINT);
+			selection = Schema.TBL_TRACKPOINT + "." + Schema.COL_ID + " = ?";
+			selectionArgs = new String[] {trackPointId};
+			break;
 		default:
 			throw new IllegalArgumentException("Unknown URI: " + uri);
 		}
@@ -462,7 +510,9 @@ public class TrackContentProvider extends ContentProvider {
 		public static final int URI_CODE_WAYPOINT_UUID = 8;
 		public static final int URI_CODE_TRACK_START = 9;
 		public static final int URI_CODE_TRACK_END = 10;
-		
+		public static final int URI_CODE_WAYPOINT_ID = 11;
+		public static final int URI_CODE_TRACKPOINT_ID = 12;
+
 
 		public static final int VAL_TRACK_ACTIVE = 1;
 		public static final int VAL_TRACK_INACTIVE = 0;

--- a/app/src/main/java/net/osmtracker/db/TracklistAdapter.java
+++ b/app/src/main/java/net/osmtracker/db/TracklistAdapter.java
@@ -90,7 +90,7 @@ public class TracklistAdapter extends CursorAdapter {
 		Track t = Track.build(trackId, cursor, context.getContentResolver(), false);
 		vTps.setText(Integer.toString(t.getTpCount()));
 		vWps.setText(Integer.toString(t.getWpCount()));
-		vNameOrStartDate.setText(t.getName());
+		vNameOrStartDate.setText(t.getDisplayName());
 
 		return v;
 	}

--- a/app/src/main/java/net/osmtracker/db/model/Point.java
+++ b/app/src/main/java/net/osmtracker/db/model/Point.java
@@ -1,0 +1,137 @@
+package net.osmtracker.db.model;
+
+import android.database.Cursor;
+
+import net.osmtracker.db.TrackContentProvider;
+
+/**
+ * WayPoint and TrackPoint inherit from this object Point
+ */
+public abstract class Point {
+
+    protected Integer id;
+    protected Integer trackId;
+    protected double latitude;
+    protected double longitude;
+    protected long pointTimestamp;
+
+    protected Double elevation;
+    protected Double accuracy;
+    protected Double compassHeading;
+    protected Double compassAccuracy;
+    protected Double atmosphericPressure;
+
+
+    protected Point(Cursor c) {
+        id = c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_ID));
+        trackId = c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_TRACK_ID));
+        latitude = c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LATITUDE));
+        longitude = c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LONGITUDE));
+        pointTimestamp = c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_TIMESTAMP));
+
+        if ( ! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION)) ) {
+            elevation = c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION));
+        }
+        if ( ! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) ) {
+            accuracy = c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY));
+        }
+        if ( ! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS)) ) {
+            compassHeading = c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS));
+        }
+        if ( ! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY)) ) {
+            compassAccuracy = c.getDouble(
+                    c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY));
+        }
+        if ( ! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ATMOSPHERIC_PRESSURE)) ) {
+            atmosphericPressure = c.getDouble(
+                    c.getColumnIndex(TrackContentProvider.Schema.COL_ATMOSPHERIC_PRESSURE));
+        }
+    }
+
+    public Point() {
+
+    }
+
+
+    public double getLatitude() {
+        return latitude;
+    }
+
+    public void setLatitude(double latitude) {
+        this.latitude = latitude;
+    }
+
+    public double getLongitude() {
+        return longitude;
+    }
+
+    public void setLongitude(double longitude) {
+        this.longitude = longitude;
+    }
+
+    public Double getElevation() {
+        return elevation;
+    }
+
+    public void setElevation(Double elevation) {
+        this.elevation = elevation;
+    }
+
+    public long getPointTimestamp() {
+        return pointTimestamp;
+    }
+
+    public void setPointTimestamp(long pointTimestamp) {
+        this.pointTimestamp = pointTimestamp;
+    }
+
+
+    public Double getAccuracy() {
+        return accuracy;
+    }
+
+    public void setAccuracy(Double accuracy) {
+        this.accuracy = accuracy;
+    }
+
+    public Double getCompassHeading() {
+        return compassHeading;
+    }
+
+    public void setCompassHeading(Double compassHeading) {
+        this.compassHeading = compassHeading;
+    }
+
+    public Double getCompassAccuracy() {
+        return compassAccuracy;
+    }
+
+    public void setCompassAccuracy(Double compassAccuracy) {
+        this.compassAccuracy = compassAccuracy;
+    }
+
+    public Double getAtmosphericPressure() {
+        return atmosphericPressure;
+    }
+
+    public void setAtmosphericPressure(Double atmosphericPressure) {
+        this.atmosphericPressure = atmosphericPressure;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Integer getTrackId() {
+        return trackId;
+    }
+
+    public void setTrackId(Integer trackId) {
+        this.trackId = trackId;
+    }
+
+}

--- a/app/src/main/java/net/osmtracker/db/model/Track.java
+++ b/app/src/main/java/net/osmtracker/db/model/Track.java
@@ -61,7 +61,7 @@ public class Track {
 	private boolean extraInformationRead = false;
 	
 	private ContentResolver cr;
-	
+
 	/**
 	 * build a track object with the given cursor
 	 * 
@@ -82,6 +82,7 @@ public class Track {
 		out.description = tc.getString(tc.getColumnIndex(TrackContentProvider.Schema.COL_DESCRIPTION));
 		
 		String tags = tc.getString(tc.getColumnIndex(TrackContentProvider.Schema.COL_TAGS));
+		//TODO: use out.setTags(tags)
 		if (tags != null && ! "".equals(tags)) {
 			out.tags.addAll(Arrays.asList(tags.split(",")));
 		}
@@ -124,6 +125,13 @@ public class Track {
 	public void setName(String name) {
 		this.name = name;
 	}
+
+	public void setTrackId(long trackId) {
+	}
+
+	public long getTrackId() {
+		return this.trackId;
+	}
 	
 	public void setDescription(String description) {
 		this.description = description;
@@ -149,12 +157,18 @@ public class Track {
 		this.startLat = startLat;
 	}
 
-	public void setTrackDate(long trackDate) {
-		this.trackDate = trackDate;
+	public void setTrackDate(long trackDate) { this.trackDate = trackDate; }
+
+	public long getTrackDate() {
+		return trackDate;
 	}
-	
+
 	public void setStartDate(long startDate) {
 		this.startDate = startDate;
+	}
+
+	public long getStartDate() {
+		return startDate;
 	}
 	
 	public void setStartLong(float startLong) {
@@ -176,8 +190,9 @@ public class Track {
 	public Integer getTpCount() {
 		return tpCount;
 	}
-	
-	public String getName() {
+
+	// @deprecated
+	public String getDisplayName() {
 		if (name != null && name.length() > 0) {
 			return name;
 		} else {
@@ -186,12 +201,28 @@ public class Track {
 		}
 	}
 
+	public String getName() { return name; }
+
 	public String getDescription() {
 		return description;
 	}
-	
+
+	public void setTags(List<String> tags) {
+		this.tags = tags;
+	}
+
+	public void setTags(String tags) {
+		if (tags != null && ! "".equals(tags)) {
+			this.tags.addAll(Arrays.asList(tags.split(",")));
+		}
+	}
+
 	public List<String> getTags() {
 		return tags;
+	}
+
+	public void setVisibility(OSMVisibility visibility) {
+		this.visibility = visibility;
 	}
 	
 	public OSMVisibility getVisibility() {

--- a/app/src/main/java/net/osmtracker/db/model/TrackPoint.java
+++ b/app/src/main/java/net/osmtracker/db/model/TrackPoint.java
@@ -1,0 +1,34 @@
+package net.osmtracker.db.model;
+
+import android.database.Cursor;
+
+import net.osmtracker.db.TrackContentProvider;
+
+/**
+ * Represents a TrackPoint
+ */
+public class TrackPoint extends Point {
+
+    private Double speed;
+
+
+    public TrackPoint(Cursor c) {
+        super(c);
+        if ( ! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_SPEED)) ) {
+            speed = c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_SPEED));
+        }
+    }
+
+    public TrackPoint() {
+
+    }
+
+
+    public Double getSpeed() {
+        return speed;
+    }
+
+    public void setSpeed(Double speed) {
+        this.speed = speed;
+    }
+}

--- a/app/src/main/java/net/osmtracker/db/model/WayPoint.java
+++ b/app/src/main/java/net/osmtracker/db/model/WayPoint.java
@@ -1,0 +1,60 @@
+package net.osmtracker.db.model;
+
+import android.database.Cursor;
+
+import net.osmtracker.db.TrackContentProvider;
+
+/**
+ * Represents a WayPoint
+ */
+public class WayPoint extends Point {
+
+    private String uuid;
+    private Integer numberOfSatellites;
+    private String name;
+    private String link;
+
+
+    public WayPoint(Cursor c) {
+        super(c);
+        uuid = c.getString(c.getColumnIndex(TrackContentProvider.Schema.COL_UUID));
+        numberOfSatellites = c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_NBSATELLITES));
+        name = c.getString(c.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
+    }
+
+    public WayPoint() {
+    }
+
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getLink() {
+        return link;
+    }
+
+    public void setLink(String link) {
+        this.link = link;
+    }
+
+    public Integer getNumberOfSatellites() {
+        return numberOfSatellites;
+    }
+
+    public void setNumberOfSatellites(Integer numberOfSatellites) {
+        this.numberOfSatellites = numberOfSatellites;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
+    }
+}

--- a/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToStorageTask.java
@@ -2,13 +2,13 @@ package net.osmtracker.gpx;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.database.Cursor;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 
 import net.osmtracker.OSMTracker;
 import net.osmtracker.R;
-import net.osmtracker.db.TrackContentProvider;
+import net.osmtracker.db.DataHelper;
+import net.osmtracker.db.model.Track;
 import net.osmtracker.exception.ExportTrackException;
 
 import java.io.File;
@@ -51,17 +51,19 @@ public class ExportToStorageTask extends ExportTrackTask {
 	}
 
 
+    /**
+     *
+     * @param startDate
+     * @return
+     */
     public String getSanitizedTrackNameByStartDate(Date startDate){
 
-        // Get the name of the track with the received start date
-        String selection = TrackContentProvider.Schema.COL_START_DATE + " = ?";
-        String[] args = {String.valueOf(startDate.getTime())};
-        Cursor cursor = context.getContentResolver().query(
-                TrackContentProvider.CONTENT_URI_TRACK, null, selection, args, null);
+        DataHelper dh = new DataHelper(context);
+        Track track = dh.getTrackByStartDate(startDate);
 
         String trackName = "";
-        if(cursor != null && cursor.moveToFirst()){
-            trackName = cursor.getString(cursor.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
+        if(track != null){
+            trackName = track.getName();
         }
         if(trackName != null && trackName.length() >= 1) {
             trackName = trackName.replace("/", "_").trim();

--- a/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
@@ -1,9 +1,9 @@
 package net.osmtracker.gpx;
 
 import android.content.Context;
-import android.database.Cursor;
 import android.util.Log;
 
+import net.osmtracker.db.model.Track;
 import net.osmtracker.exception.ExportTrackException;
 
 import java.io.File;
@@ -38,9 +38,8 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 		return tmpFile.getParentFile();
 	}
 
-	@Override
-	public String buildGPXFilename(Cursor c, File parentDirectory) {
-		filename = super.buildGPXFilename(c, parentDirectory);
+	public String buildGPXFilename(Track track, File parentDirectory) {
+		filename = super.buildGPXFilename(track, parentDirectory);
 		return tmpFile.getName();
 	}
 

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -261,7 +261,7 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 	 * @param target Target GPX file
 	 * @throws IOException
 	 */
-	private void writeGpxFile(Track track, File target)
+	protected void writeGpxFile(Track track, File target)
 			throws IOException {
 
 		String accuracyOutput = PreferenceManager.getDefaultSharedPreferences(context).getString(
@@ -396,14 +396,14 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 					+ CDATA_END+"</cmt>"+"\n");
 		}
 
-		String buff = "";
+		String extensions = "";
 		if(trkpt.getSpeed() != null) {
-			buff += "\t\t\t\t\t" + "<speed>" + trkpt.getSpeed() + "</speed>" + "\n";
+			extensions += "\t\t\t\t\t" + "<speed>" + trkpt.getSpeed() + "</speed>" + "\n";
 		}
 		if ( OSMTracker.Preferences.VAL_OUTPUT_COMPASS_EXTENSION.equals(compass)
 				&& trkpt.getCompassHeading() != null ) {
-			buff += "\t\t\t\t\t" + "<compass>" + trkpt.getCompassHeading() + "</compass>" + "\n";
-			buff += "\t\t\t\t\t" + "<compass_accuracy>" + trkpt.getCompassAccuracy()
+			extensions += "\t\t\t\t\t" + "<compass>" + trkpt.getCompassHeading() + "</compass>" + "\n";
+			extensions += "\t\t\t\t\t" + "<compass_accuracy>" + trkpt.getCompassAccuracy()
 					+ "</compass_accuracy>" + "\n";
 		}
 
@@ -411,12 +411,12 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 		if (trkpt.getAtmosphericPressure() != null ) {
 			double pressure = trkpt.getAtmosphericPressure();
 			String pressure_formatted = String.format("%.1f", pressure);
-			buff += "\t\t\t\t\t" + "<baro>" + pressure_formatted + "</baro>" + "\n";
+			extensions += "\t\t\t\t\t" + "<baro>" + pressure_formatted + "</baro>" + "\n";
 		}
 
-		if(! buff.equals("")) {
+		if(! extensions.equals("")) {
 			out.append("\t\t\t\t" + "<extensions>\n");
-			out.append(buff);
+			out.append(extensions);
 			out.append("\t\t\t\t" + "</extensions>\n");
 		}
 

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -3,13 +3,10 @@ package net.osmtracker.gpx;
 import android.Manifest;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
-import android.content.ContentResolver;
-import android.content.ContentUris;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.pm.PackageManager;
-import android.database.Cursor;
 import android.media.MediaScannerConnection;
 import android.os.AsyncTask;
 import android.os.Environment;
@@ -21,7 +18,9 @@ import android.widget.Toast;
 import net.osmtracker.OSMTracker;
 import net.osmtracker.R;
 import net.osmtracker.db.DataHelper;
-import net.osmtracker.db.TrackContentProvider;
+import net.osmtracker.db.model.Track;
+import net.osmtracker.db.model.TrackPoint;
+import net.osmtracker.db.model.WayPoint;
 import net.osmtracker.exception.ExportTrackException;
 import net.osmtracker.util.FileSystemUtils;
 
@@ -34,6 +33,7 @@ import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 
@@ -198,7 +198,7 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 		}
 	}
 
-	private void exportTrackAsGpx(long trackId) throws ExportTrackException {
+	protected void exportTrackAsGpx(long trackId) throws ExportTrackException {
 
 		String state = Environment.getExternalStorageState();
 		File sdRoot = Environment.getExternalStorageDirectory();
@@ -207,11 +207,10 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 				Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
 
 			if (sdRoot.canWrite()) {
-				ContentResolver cr = context.getContentResolver();
 
-				Cursor c = context.getContentResolver().query(ContentUris.withAppendedId(
-						TrackContentProvider.CONTENT_URI_TRACK, trackId), null, null,
-						null, null);
+				//refactoring
+				DataHelper dh = new DataHelper(context);
+				Track track = dh.getTrackById(trackId);
 
 				// Get the startDate of this track
 				// TODO: Maybe we should be pulling the track name instead?
@@ -220,45 +219,25 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 				// to avoid overwriting another track on one hand or needlessly creating additional
 				// directories to avoid overwriting.
 				Date startDate = new Date();
-				if (null != c && 1 <= c.getCount()) {
-					c.moveToFirst();
-					long startDateInMilliseconds = c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_START_DATE));
-					startDate.setTime(startDateInMilliseconds);
-				}
+				long startDateInMilliseconds = track.getTrackDate();
+				startDate.setTime(startDateInMilliseconds);
 
 				File trackGPXExportDirectory = getExportDirectory(startDate);
-				String filenameBase = buildGPXFilename(c, trackGPXExportDirectory);
-
-
-				String tags = c.getString(c.getColumnIndex(TrackContentProvider.Schema.COL_TAGS));
-				String track_description = c.getString(c.getColumnIndex(TrackContentProvider.Schema.COL_DESCRIPTION));
-				String track_name = c.getString(c.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
-
-				c.close();
-
+				String filenameBase = buildGPXFilename(track, trackGPXExportDirectory);
 				File trackFile = new File(trackGPXExportDirectory, filenameBase);
 
-				Cursor cTrackPoints = cr.query(TrackContentProvider.trackPointsUri(trackId), null,
-						null, null, TrackContentProvider.Schema.COL_TIMESTAMP + " asc");
-				Cursor cWayPoints = cr.query(TrackContentProvider.waypointsUri(trackId), null, null,
-						null, TrackContentProvider.Schema.COL_TIMESTAMP + " asc");
-
-				if (null != cTrackPoints && null != cWayPoints) {
-					publishProgress(trackId, (long) cTrackPoints.getCount(), (long) cWayPoints.getCount());
-
+				if (track.getTpCount() != 0 && 0 != track.getWpCount()) {
 					try {
-						writeGpxFile(track_name, tags, track_description, cTrackPoints, cWayPoints, trackFile);
+						writeGpxFile(track, trackFile);
+
 						if (exportMediaFiles()) {
 							copyWaypointFiles(trackId, trackGPXExportDirectory);
 						}
 						if (updateExportDate()) {
-							DataHelper.setTrackExportDate(trackId, System.currentTimeMillis(), cr);
+							dh.setTrackExportDate(trackId, System.currentTimeMillis());
 						}
 					} catch (IOException ioe) {
 						throw new ExportTrackException(ioe.getMessage());
-					} finally {
-						cTrackPoints.close();
-						cWayPoints.close();
 					}
 
 					// Force rescan of directory
@@ -266,24 +245,24 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 					for (File file : trackGPXExportDirectory.listFiles()) {
 						files.add(file.getAbsolutePath());
 					}
-					MediaScannerConnection.scanFile(context, files.toArray(new String[0]), null, null);
+					MediaScannerConnection.scanFile(context, files.toArray(new String[0]),
+							null, null);
 
 				}
 			} else {
-				throw new ExportTrackException(context.getResources().getString(R.string.error_externalstorage_not_writable));
+				throw new ExportTrackException(context.getResources()
+						.getString(R.string.error_externalstorage_not_writable));
 			}
 		}
-
 	}
 
 	/**
 	 * Writes the GPX file
-	 * @param cTrackPoints Cursor to track points.
-	 * @param cWayPoints Cursor to way points.
 	 * @param target Target GPX file
 	 * @throws IOException
 	 */
-	private void writeGpxFile(String trackName, String tags, String track_description, Cursor cTrackPoints, Cursor cWayPoints, File target) throws IOException {
+	private void writeGpxFile(Track track, File target)
+			throws IOException {
 
 		String accuracyOutput = PreferenceManager.getDefaultSharedPreferences(context).getString(
 				OSMTracker.Preferences.KEY_OUTPUT_ACCURACY,
@@ -305,22 +284,12 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 			writer.write(XML_HEADER + "\n");
 			writer.write(TAG_GPX + "\n");
 
-			writer.write("\t<metadata>\n");
+			String metadata = buildMetadataString(track);
+			writer.write(metadata);
 
-			// Write the track's name to a tag
-			if((trackName != null && !trackName.equals(""))) writer.write("\t\t<name>"+ trackName +"</name>\n");
+			writeWayPoints(writer, track.getTrackId(), accuracyOutput, fillHDOP, compassOutput);
+			writeTrackPoints(writer, track.getTrackId(), fillHDOP, compassOutput);
 
-			if (tags != null && !tags.equals("")) {
-				for (String tag : tags.split(","))
-					writer.write("\t\t<keywords>" + tag.trim() + "</keywords>\n");
-			}
-
-			if ((track_description != null && !track_description.equals(""))) writer.write("\t\t<desc>" + track_description + "</desc>\n");
-
-			writer.write("\t</metadata>\n");
-
-			writeWayPoints(writer, cWayPoints, accuracyOutput, fillHDOP, compassOutput);
-			writeTrackPoints(context.getResources().getString(R.string.gpx_track_name), writer, cTrackPoints, fillHDOP, compassOutput);
 			writer.write("</gpx>");
 
 		} finally {
@@ -331,23 +300,50 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 	}
 
 	/**
+	 * Build a string with the metadata of the gpx
+	 *
+	 * @param track
+	 * @return
+	 */
+	protected String buildMetadataString(Track track) {
+		StringBuilder metadata = new StringBuilder();
+		metadata.append("\t<metadata>\n");
+
+		// Write the track's name to a tag
+		String trackName = track.getName();
+		if((trackName != null && !trackName.equals(""))) {
+			metadata.append("\t\t<name>" + trackName + "</name>\n");
+		}
+
+		for (String tag : track.getTags()) {
+			metadata.append("\t\t<keywords>" + tag.trim() + "</keywords>\n");
+		}
+
+		String trackDescription = track.getDescription();
+		if ((trackDescription != null && !trackDescription.equals(""))){
+			metadata.append("\t\t<desc>" + trackDescription + "</desc>\n");
+		}
+
+		metadata.append("\t</metadata>\n");
+		return metadata.toString();
+	}
+
+
+	/**
 	 * Iterates on track points and write them.
-	 * @param trackName Name of the track (metadata).
 	 * @param fw Writer to the target file.
-	 * @param c Cursor to track points.
+	 * @param trackId
 	 * @param fillHDOP Indicates whether fill <hdop> tag with approximation from location accuracy.
 	 * @param compass Indicates if and how to write compass heading to the GPX ('none', 'comment', 'extension')
 	 * @throws IOException
 	 */
-	private void writeTrackPoints(String trackName, Writer fw, Cursor c, boolean fillHDOP, String compass) throws IOException {
-		// Update dialog every 1%
-		int dialogUpdateThreshold = c.getCount() / 100;
-		if (dialogUpdateThreshold == 0) {
-			dialogUpdateThreshold++;
-		}
+	private void writeTrackPoints(Writer fw, long trackId, boolean fillHDOP, String compass) throws IOException {
+		DataHelper dh = new DataHelper(context);
+		List<Integer> trackPointsId = dh.getTrackPointIdsOfTrack(trackId);
 
 		fw.write("\t" + "<trk>" + "\n");
-		fw.write("\t\t" + "<name>" + CDATA_START + trackName + CDATA_END + "</name>" + "\n");
+		String GPXTrackName = context.getResources().getString(R.string.gpx_track_name);
+		fw.write("\t\t" + "<name>" + CDATA_START + GPXTrackName + CDATA_END + "</name>" + "\n");
 		if (fillHDOP) {
 			fw.write("\t\t" + "<cmt>"
 					+ CDATA_START
@@ -357,55 +353,13 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 		}
 		fw.write("\t\t" + "<trkseg>" + "\n");
 
-		int i=0;
-		for(c.moveToFirst(); !c.isAfterLast(); c.moveToNext(),i++) {
-			StringBuffer out = new StringBuffer();
-			out.append("\t\t\t" + "<trkpt lat=\""
-					+ c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LATITUDE)) + "\" "
-					+ "lon=\"" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LONGITUDE)) + "\">" + "\n");
-			if (! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION))) {
-				out.append("\t\t\t\t" + "<ele>" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION)) + "</ele>" + "\n");
-			}
-			out.append("\t\t\t\t" + "<time>" + pointDateFormatter.format(new Date(c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_TIMESTAMP)))) + "</time>" + "\n");
+		TrackPoint trkpt;
+		String trkptString;
+		for (Integer trackPointId : trackPointsId) {
+			trkpt = dh.getTrackPointById(trackPointId);
+			trkptString = buildTrackPointString(trkpt, fillHDOP, compass);
+			fw.write(trkptString);
 
-			if(fillHDOP && ! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY))) {
-				out.append("\t\t\t\t" + "<hdop>" + (c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) / OSMTracker.HDOP_APPROXIMATION_FACTOR) + "</hdop>" + "\n");
-			}
-			if(OSMTracker.Preferences.VAL_OUTPUT_COMPASS_COMMENT.equals(compass) && !c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))) {
-				out.append("\t\t\t\t" + "<cmt>"+CDATA_START+"compass: " +
-						c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))+
-						"\n\t\t\t\t\tcompAccuracy: " +
-						c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY))+
-						CDATA_END+"</cmt>"+"\n");
-			}
-
-			String buff = "";
-			if(! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_SPEED))) {
-				buff += "\t\t\t\t\t" + "<speed>" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_SPEED)) + "</speed>" + "\n";
-			}
-			if(OSMTracker.Preferences.VAL_OUTPUT_COMPASS_EXTENSION.equals(compass) && !c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))) {
-				buff += "\t\t\t\t\t" + "<compass>" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS)) + "</compass>" + "\n";
-				buff += "\t\t\t\t\t" + "<compass_accuracy>" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY)) + "</compass_accuracy>" + "\n";
-			}
-
-			if (! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ATMOSPHERIC_PRESSURE))) { //Checking if the database contains atmospheric_pressure data
-				double pressure = c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ATMOSPHERIC_PRESSURE));
-				String pressure_formatted = String.format("%.1f", pressure);
-				buff += "\t\t\t\t\t" + "<baro>" + pressure_formatted + "</baro>" + "\n";
-			}
-
-			if(! buff.equals("")) {
-				out.append("\t\t\t\t" + "<extensions>\n");
-				out.append(buff);
-				out.append("\t\t\t\t" + "</extensions>\n");
-			}
-
-			out.append("\t\t\t" + "</trkpt>" + "\n");
-			fw.write(out.toString());
-
-			if (i % dialogUpdateThreshold == 0) {
-				publishProgress((long) dialogUpdateThreshold);
-			}
 		}
 
 		fw.write("\t\t" + "</trkseg>" + "\n");
@@ -413,123 +367,190 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 	}
 
 	/**
+	 *
+	 * @param trkpt
+	 * @param fillHDOP
+	 * @param compass
+	 * @return
+	 */
+	protected String buildTrackPointString(TrackPoint trkpt, boolean fillHDOP, String compass) {
+		StringBuilder out = new StringBuilder();
+		out.append("\t\t\t" + "<trkpt lat=\"" + trkpt.getLatitude() + "\" "
+				+ "lon=\"" + trkpt.getLongitude() + "\">" + "\n");
+		if (trkpt.getElevation() != null) {
+			out.append("\t\t\t\t" + "<ele>" + trkpt.getElevation() + "</ele>" + "\n");
+		}
+		out.append("\t\t\t\t" + "<time>"
+				+ pointDateFormatter.format(new Date(trkpt.getPointTimestamp()))
+				 + "</time>" + "\n");
+
+		if(fillHDOP && trkpt.getAccuracy() != null) {
+			out.append("\t\t\t\t" + "<hdop>"
+					+ (trkpt.getAccuracy() / OSMTracker.HDOP_APPROXIMATION_FACTOR)
+					+ "</hdop>" + "\n");
+		}
+		if(OSMTracker.Preferences.VAL_OUTPUT_COMPASS_COMMENT.equals(compass)
+				&& trkpt.getCompassHeading() != null) {
+			out.append("\t\t\t\t" + "<cmt>"+CDATA_START+"compass: " + trkpt.getCompassHeading()
+					+ "\n\t\t\t\t\tcompAccuracy: " + trkpt.getCompassAccuracy()
+					+ CDATA_END+"</cmt>"+"\n");
+		}
+
+		String buff = "";
+		if(trkpt.getSpeed() != null) {
+			buff += "\t\t\t\t\t" + "<speed>" + trkpt.getSpeed() + "</speed>" + "\n";
+		}
+		if ( OSMTracker.Preferences.VAL_OUTPUT_COMPASS_EXTENSION.equals(compass)
+				&& trkpt.getCompassHeading() != null ) {
+			buff += "\t\t\t\t\t" + "<compass>" + trkpt.getCompassHeading() + "</compass>" + "\n";
+			buff += "\t\t\t\t\t" + "<compass_accuracy>" + trkpt.getCompassAccuracy()
+					+ "</compass_accuracy>" + "\n";
+		}
+
+		//Checking if the database contains atmospheric_pressure data
+		if (trkpt.getAtmosphericPressure() != null ) {
+			double pressure = trkpt.getAtmosphericPressure();
+			String pressure_formatted = String.format("%.1f", pressure);
+			buff += "\t\t\t\t\t" + "<baro>" + pressure_formatted + "</baro>" + "\n";
+		}
+
+		if(! buff.equals("")) {
+			out.append("\t\t\t\t" + "<extensions>\n");
+			out.append(buff);
+			out.append("\t\t\t\t" + "</extensions>\n");
+		}
+
+		out.append("\t\t\t" + "</trkpt>" + "\n");
+
+		return out.toString();
+	}
+
+
+	/**
 	 * Iterates on way points and write them.
 	 * @param fw Writer to the target file.
-	 * @param c Cursor to way points.
+	 * @param trackId
 	 * @param accuracyInfo Constant describing how to include (or not) accuracy info for way points.
 	 * @param fillHDOP Indicates whether fill <hdop> tag with approximation from location accuracy.
-	 * @param compass Indicates if and how to write compass heading to the GPX ('none', 'comment', 'extension')
+	 * @param compass Indicates if and how to write compass heading to the GPX ('none', 'comment',
+	 *                   'extension')
 	 * @throws IOException
 	 */
-	private void writeWayPoints(Writer fw, Cursor c, String accuracyInfo, boolean fillHDOP, String compass) throws IOException {
+	private void writeWayPoints(Writer fw, long trackId, String accuracyInfo, boolean fillHDOP,
+								String compass) throws IOException {
 
-		// Update dialog every 1%
-		int dialogUpdateThreshold = c.getCount() / 100;
-		if (dialogUpdateThreshold == 0) {
-			dialogUpdateThreshold++;
+		DataHelper dh = new DataHelper(context);
+		List<Integer> waypointIds = dh.getWayPointIdsOfTrack(trackId);
+
+		WayPoint wpt;
+		String wptString;
+		for (Integer wayPointId : waypointIds) {
+			wpt = dh.getWayPointById(wayPointId);
+			wptString = buildWayPointString(wpt, accuracyInfo, fillHDOP, compass);
+			fw.write(wptString);
 		}
+	}
+
+
+	/**
+	 * @param wpt WayPoint object
+	 * @param accuracyInfo Constant describing how to include (or not) accuracy info for way points.
+	 * @param fillHDOP Indicates whether fill <hdop> tag with approximation from location accuracy.
+	 * @param compass Indicates if and how to write compass heading to the GPX ('none', 'comment',
+	 *                  'extension')
+	 * @return
+	 */
+	protected String buildWayPointString(WayPoint wpt, String accuracyInfo, boolean fillHDOP,
+											  String compass) {
 
 		// Label for meter unit
 		String meterUnit = context.getResources().getString(R.string.various_unit_meters);
 		// Word "accuracy"
 		String accuracy = context.getResources().getString(R.string.various_accuracy);
 
-		int i=0;
-		for(c.moveToFirst(); !c.isAfterLast(); c.moveToNext(), i++) {
-			StringBuilder out = new StringBuilder();
-			out.append("\t" + "<wpt lat=\""
-					+ c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LATITUDE)) + "\" "
-					+ "lon=\"" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LONGITUDE)) + "\">" + "\n");
-			if (! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION))) {
-				out.append("\t\t" + "<ele>" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ELEVATION)) + "</ele>" + "\n");
-			}
-			out.append("\t\t" + "<time>" + pointDateFormatter.format(new Date(c.getLong(c.getColumnIndex(TrackContentProvider.Schema.COL_TIMESTAMP)))) + "</time>" + "\n");
-
-			String name = c.getString(c.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
-
-			if (! OSMTracker.Preferences.VAL_OUTPUT_ACCURACY_NONE.equals(accuracyInfo) && ! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY))) {
-				// Outputs accuracy info for way point
-				if (OSMTracker.Preferences.VAL_OUTPUT_ACCURACY_WPT_NAME.equals(accuracyInfo)) {
-					// Output accuracy with name
-					out.append("\t\t" + "<name>"
-							+ CDATA_START
-							+ name
-							+ " (" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) + meterUnit + ")"
-							+ CDATA_END
-							+ "</name>" + "\n");
-					if (OSMTracker.Preferences.VAL_OUTPUT_COMPASS_COMMENT.equals(compass) &&
-							! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))) {
-						out.append("\t\t"+ "<cmt>" + CDATA_START + "compass: " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS)) +
-								"\n\t\t\tcompass accuracy: " + c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY)) + CDATA_END + "</cmt>\n");
-					}
-				} else if (OSMTracker.Preferences.VAL_OUTPUT_ACCURACY_WPT_CMT.equals(accuracyInfo)) {
-					// Output accuracy in separate tag
-					out.append("\t\t" + "<name>" + CDATA_START + name + CDATA_END + "</name>" + "\n");
-					if (OSMTracker.Preferences.VAL_OUTPUT_COMPASS_COMMENT.equals(compass) &&
-							! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))) {
-						out.append("\t\t" + "<cmt>" + CDATA_START + accuracy + ": " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) + meterUnit +
-								"\n\t\t\t compass heading: " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS)) +
-								"deg\n\t\t\t compass accuracy: " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY)) +CDATA_END + "</cmt>" + "\n");
-					} else {
-						out.append("\t\t" + "<cmt>" + CDATA_START + accuracy + ": " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) + meterUnit + CDATA_END + "</cmt>" + "\n");
-					}
-				} else {
-					// Unknown value for accuracy info, shouldn't occur but who knows ?
-					// See issue #68. Output at least the name just in case.
-					out.append("\t\t" + "<name>" + CDATA_START + name + CDATA_END + "</name>" + "\n");
-				}
-			} else {
-				// No accuracy info requested, or available
-				out.append("\t\t" + "<name>" + CDATA_START + name + CDATA_END + "</name>" + "\n");
-				if (OSMTracker.Preferences.VAL_OUTPUT_COMPASS_COMMENT.equals(compass) &&
-						! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))) {
-					out.append("\t\t"+ "<cmt>" + CDATA_START + "compass: " + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS)) +
-							"\n\t\t\tcompass accuracy: " + c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY)) + CDATA_END + "</cmt>\n");
-				}
-			}
-
-			String link = c.getString(c.getColumnIndex(TrackContentProvider.Schema.COL_LINK));
-			if (link != null) {
-				out.append("\t\t" + "<link href=\"" + URLEncoder.encode(link) + "\">" + "\n");
-				out.append("\t\t\t" + "<text>" + link +"</text>\n");
-				out.append("\t\t" + "</link>" + "\n");
-			}
-
-			if (! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_NBSATELLITES))) {
-				out.append("\t\t" + "<sat>" + c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_NBSATELLITES)) + "</sat>" + "\n");
-			}
-
-			if(fillHDOP && ! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY))) {
-				out.append("\t\t" + "<hdop>" + (c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ACCURACY)) / OSMTracker.HDOP_APPROXIMATION_FACTOR) + "</hdop>" + "\n");
-			}
-
-			String buff = "";
-
-			if(OSMTracker.Preferences.VAL_OUTPUT_COMPASS_EXTENSION.equals(compass) && !c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS))) {
-				buff += "\t\t\t\t\t" + "<compass>" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS)) + "</compass>" + "\n";
-				buff += "\t\t\t\t\t" + "<compass_accuracy>" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_COMPASS_ACCURACY)) + "</compass_accuracy>" + "\n";
-			}
-
-			if (! c.isNull(c.getColumnIndex(TrackContentProvider.Schema.COL_ATMOSPHERIC_PRESSURE))) { //Checking if the database contains atmospheric_pressure data
-				double pressure = c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_ATMOSPHERIC_PRESSURE));
-				String pressure_formatted = String.format("%.1f", pressure);
-				buff += "\t\t\t\t\t" + "<baro>" + pressure_formatted + "</baro>" + "\n";
-			}
-
-			if(! buff.equals("")) {
-				out.append("\t\t\t\t" + "<extensions>\n");
-				out.append(buff);
-				out.append("\t\t\t\t" + "</extensions>\n");
-			}
-
-			out.append("\t" + "</wpt>" + "\n");
-
-			fw.write(out.toString());
-
-			if (i % dialogUpdateThreshold == 0) {
-				publishProgress((long) dialogUpdateThreshold);
-			}
+		StringBuilder out = new StringBuilder();
+		out.append("\t" + "<wpt lat=\"" + wpt.getLatitude() + "\" " + "lon=\""
+				+ wpt.getLongitude() + "\">" + "\n");
+		if (wpt.getElevation() != null) {
+			out.append("\t\t" + "<ele>" + wpt.getElevation() + "</ele>" + "\n");
 		}
+		out.append("\t\t" + "<time>" + pointDateFormatter.format(
+				new Date(wpt.getPointTimestamp())) + "</time>" + "\n");
+
+		// name (optionally with accuracy)
+		out.append("\t\t" + "<name>" + CDATA_START + wpt.getName());
+		// accuracy should be included with name?
+		if (OSMTracker.Preferences.VAL_OUTPUT_ACCURACY_WPT_NAME.equals(accuracyInfo)
+				&& wpt.getAccuracy() != null) {
+			// Add accuracy to name
+			out.append(" (" + wpt.getAccuracy() + meterUnit + ")");
+		}
+		out.append(CDATA_END + "</name>" + "\n");
+
+		// Comment with accuracy and/or compass (optionally)
+		String comment = "";
+		if (OSMTracker.Preferences.VAL_OUTPUT_ACCURACY_WPT_CMT.equals(accuracyInfo)
+				&& wpt.getAccuracy() != null) {
+			comment += accuracy + ": " + wpt.getAccuracy() + meterUnit;
+		}
+		if (OSMTracker.Preferences.VAL_OUTPUT_COMPASS_COMMENT.equals(compass)
+				&& wpt.getCompassHeading() != null) {
+			if (! comment.equals("") ) {
+				comment += "\n\t\t\t";
+			}
+			comment += "compass heading: " + wpt.getCompassHeading() + "deg"
+					+ "\n\t\t\tcompass accuracy: " + wpt.getCompassAccuracy();
+		}
+		if (! comment.equals("")) {
+			out.append("\t\t" + "<cmt>" + CDATA_START + comment + CDATA_END + "</cmt>" + "\n");
+		}
+
+
+		String link = wpt.getLink();
+		if (link != null) {
+			out.append("\t\t" + "<link href=\"" + URLEncoder.encode(link) + "\">" + "\n");
+			out.append("\t\t\t" + "<text>" + link +"</text>\n");
+			out.append("\t\t" + "</link>" + "\n");
+		}
+
+		if (wpt.getNumberOfSatellites() != null) {
+			out.append("\t\t" + "<sat>" + wpt.getNumberOfSatellites() + "</sat>" + "\n");
+		}
+
+		if(fillHDOP && wpt.getAccuracy() != null) {
+			out.append("\t\t" + "<hdop>"
+					+ (wpt.getAccuracy() / OSMTracker.HDOP_APPROXIMATION_FACTOR)
+					+ "</hdop>" + "\n");
+		}
+
+
+		String extensions = "";
+
+		if(OSMTracker.Preferences.VAL_OUTPUT_COMPASS_EXTENSION.equals(compass)
+				&& wpt.getCompassHeading() != null) {
+			extensions += "\t\t\t\t\t" + "<compass>" + wpt.getCompassHeading()
+					+ "</compass>" + "\n";
+			extensions += "\t\t\t\t\t" + "<compass_accuracy>" + wpt.getCompassAccuracy()
+					+ "</compass_accuracy>" + "\n";
+		}
+
+		//Checking if the database contains atmospheric_pressure data
+		if (wpt.getAtmosphericPressure() != null) {
+			double pressure = wpt.getAtmosphericPressure();
+			String pressure_formatted = String.format("%.1f", pressure);
+			extensions += "\t\t\t\t\t" + "<baro>" + pressure_formatted + "</baro>" + "\n";
+		}
+
+		if(! extensions.equals("")) {
+			out.append("\t\t\t\t" + "<extensions>\n");
+			out.append(extensions);
+			out.append("\t\t\t\t" + "</extensions>\n");
+		}
+
+		out.append("\t" + "</wpt>" + "\n");
+
+		return out.toString();
+
 	}
 
 	/**
@@ -552,18 +573,18 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 	 * The filename will have the start date, and/or the track name if available.
 	 * If no name is available, fall back to the start date and time.
 	 * Track name characters will be sanitized using {@link #FILENAME_CHARS_BLACKLIST_PATTERN}.
-	 * @param cursor  Track info: {@link TrackContentProvider.Schema#COL_NAME}, {@link TrackContentProvider.Schema#COL_START_DATE}
+	 * @param track  Track info: {@link Track}
 	 * @return  GPX filename, not including the path
 	 */
-	public String buildGPXFilename(Cursor cursor, File parentDirectory) {
+	public String buildGPXFilename(Track track, File parentDirectory) {
 		String desiredOutputFormat = PreferenceManager.getDefaultSharedPreferences(context).getString(
 				OSMTracker.Preferences.KEY_OUTPUT_FILENAME,
 				OSMTracker.Preferences.VAL_OUTPUT_FILENAME);
 
-		long trackStartDate = cursor.getLong(cursor.getColumnIndex(TrackContentProvider.Schema.COL_START_DATE));
+		long trackStartDate = track.getStartDate();
 		String formattedTrackStartDate = DataHelper.FILENAME_FORMATTER.format(new Date(trackStartDate));
 
-		String trackName =  cursor.getString(cursor.getColumnIndex(TrackContentProvider.Schema.COL_NAME));
+		String trackName =  track.getName();
 		if(trackName != null)
 			trackName = sanitizeTrackName(trackName);
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -72,7 +72,12 @@
 			android:title="@string/prefs_output_gpx_hdop_approximation"
 			android:summary="@string/prefs_output_gpx_hdop_approximation_summary"
 			android:defaultValue="false" />
-		<ListPreference android:key="gpx.compass_heading" android:summary="@string/prefs_compass_heading_summary" android:title="@string/prefs_compass_heading" android:entryValues="@array/prefs_compass_heading_values" android:entries="@array/prefs_compass_heading_keys"/>
+		<ListPreference
+			android:key="gpx.compass_heading"
+			android:summary="@string/prefs_compass_heading_summary"
+			android:title="@string/prefs_compass_heading"
+			android:entryValues="@array/prefs_compass_heading_values"
+			android:entries="@array/prefs_compass_heading_keys"/>
 	</PreferenceCategory>
 
 	<PreferenceCategory android:title="@string/prefs_ui">

--- a/app/src/test/assets/gpx/gpx-test.gpx
+++ b/app/src/test/assets/gpx/gpx-test.gpx
@@ -1,43 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/nguillaumin/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
-	<wpt lat="34.12" lon="18.45">
-		<ele>5812.2</ele>
-		<time>2012-03-12T16:46:38Z</time>
-		<name><![CDATA[wp1]]></name>
-		<link href="http%3A%2F%2Flink1.com">
-			<text>http://link1.com</text>
-		</link>
-		<sat>2</sat>
-		<hdop>0.0625</hdop>
-	</wpt>
-	<wpt lat="43.76" lon="31.89">
-		<ele>75.4</ele>
-		<time>2012-03-12T16:46:38Z</time>
-		<name><![CDATA[wp2]]></name>
-		<link href="http%3A%2F%2Flink2.com">
-			<text>http://link2.com</text>
-		</link>
-		<sat>6</sat>
-		<hdop>0.1525000035762787</hdop>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="OSMTracker for Android™ - https://github.com/labexp/osmtracker-android" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd ">
+	<metadata>
+		<name>2020-12-30_17-20-17</name>
+		<keywords>osmtracker</keywords>
+	</metadata>
+	<wpt lat="10.0375634848231" lon="-84.2123549868801">
+		<ele>1029.89940680377</ele>
+		<time>2001-05-16T23:20:28Z</time>
+		<name><![CDATA[Punto de prueba]]></name>
+		<sat>0</sat>
+		<hdop>6.0</hdop>
+				<extensions>
+					<compass>204.029998779297</compass>
+					<compass_accuracy>2.0</compass_accuracy>
+				</extensions>
 	</wpt>
 	<trk>
-		<name><![CDATA[Tracked with OSMTracker for Android™]]></name>
-		<cmt><![CDATA[Warning: HDOP values aren't the HDOP as returned by the GPS device. They're approximated from the location accuracy in meters.]]></cmt>
+		<name><![CDATA[Trazado con OSMTracker para Android™]]></name>
+		<cmt><![CDATA[Advertencia: los valores HDOP no son los valores HDOP devueltos por el dispositivo GPS. Son valores aproximados de acuerdo a la precisión de la ubicación en metros.]]></cmt>
 		<trkseg>
-			<trkpt lat="12.34" lon="56.78">
-				<ele>4321.7</ele>
-				<time>2012-03-12T16:46:38Z</time>
-				<hdop>0.10499999672174454</hdop>
+			<trkpt lat="10.0375690436648" lon="-84.2122886824885">
+				<ele>1015.13159253262</ele>
+				<time>2001-05-16T23:20:25Z</time>
+				<hdop>8.908860206604</hdop>
 				<extensions>
-					<speed>45.79999923706055</speed>
+					<speed>0.361938893795013</speed>
+					<compass>204.690002441406</compass>
+					<compass_accuracy>2.0</compass_accuracy>
 				</extensions>
 			</trkpt>
-			<trkpt lat="21.57" lon="12.6">
-				<ele>12.1</ele>
-				<time>2012-03-12T16:46:38Z</time>
-				<hdop>0.05999999865889549</hdop>
+			<trkpt lat="10.0377106969496" lon="-84.2123268390527">
+				<ele>1007.3209409276</ele>
+				<time>2001-05-16T23:20:26Z</time>
+				<hdop>13.0176601409912</hdop>
 				<extensions>
-					<speed>12.600000381469727</speed>
+					<speed>0.271533757448196</speed>
+					<compass>204.360000610352</compass>
+					<compass_accuracy>2.0</compass_accuracy>
 				</extensions>
 			</trkpt>
 		</trkseg>

--- a/app/src/test/java/net/osmtracker/data/GPXMocks.java
+++ b/app/src/test/java/net/osmtracker/data/GPXMocks.java
@@ -1,0 +1,13 @@
+package net.osmtracker.data;
+
+public class GPXMocks {
+
+    //name = Nombre de la traza, keywords= osmtracker
+    public static String MOCK_WAYPOINT_XML_A =
+            "\t<metadata>\n"
+                    +"\t\t<name>Nombre de la traza</name>\n"
+                    +"\t\t<keywords>OSMTracker</keywords>\n"
+                    +"\t\t<keywords>bekuo</keywords>\n"
+                    +"\t\t<desc>Descripción de prueba</desc>\n"
+                    +"\t</metadata>\n";
+}

--- a/app/src/test/java/net/osmtracker/data/GPXMocks.java
+++ b/app/src/test/java/net/osmtracker/data/GPXMocks.java
@@ -2,8 +2,8 @@ package net.osmtracker.data;
 
 public class GPXMocks {
 
-    //name = Nombre de la traza, keywords= osmtracker
-    public static String MOCK_WAYPOINT_XML_A =
+    //name = Nombre de la traza, keywords= OSMTracker and Bekuo
+    public static String MOCK_METADATA_XML_A =
             "\t<metadata>\n"
                     +"\t\t<name>Nombre de la traza</name>\n"
                     +"\t\t<keywords>OSMTracker</keywords>\n"

--- a/app/src/test/java/net/osmtracker/data/MockDataHelper.java
+++ b/app/src/test/java/net/osmtracker/data/MockDataHelper.java
@@ -1,0 +1,58 @@
+package net.osmtracker.data;
+
+import android.content.Context;
+
+import net.osmtracker.db.DataHelper;
+import net.osmtracker.db.model.Track;
+import net.osmtracker.db.model.TrackPoint;
+import net.osmtracker.db.model.WayPoint;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+public class MockDataHelper extends DataHelper {
+
+    public MockDataHelper(Context context) {
+        super(context);
+    }
+
+    public void setTrackExportDate(long trackId, long exportTime){
+        //ok
+    }
+
+
+    public Track getTrackByStartDate(Date startDate) {
+        return TrackMocks.getMockTrackForGPX();
+    }
+
+    public Track getTrackById(long trackId) {
+        return TrackMocks.getMockTrackForGPX();
+    }
+
+    public List<Integer> getWayPointIdsOfTrack(long trackId) {
+        List<Integer> out = new ArrayList<Integer>();
+        int i = 1;
+        for(; i <= WayPointMocks.GPX_WAYPOINTS_COUNT; i++) {
+            out.add(new Integer(i));
+        }
+        return out;
+    }
+
+    public WayPoint getWayPointById(Integer wayPointId) {
+        return WayPointMocks.getMockWayPointForGPX(wayPointId);
+    }
+
+    public List<Integer> getTrackPointIdsOfTrack(long trackId) {
+        List<Integer> out = new ArrayList<Integer>();
+        int i = 1;
+        for(; i <= TrackPointMocks.GPX_TRACKPOINTS_COUNT; i++) {
+            out.add(new Integer(i));
+        }
+        return out;
+    }
+
+    public TrackPoint getTrackPointById(Integer trackPointId) {
+        return TrackPointMocks.getMockTrackPointForGPX(trackPointId);
+    }
+}

--- a/app/src/test/java/net/osmtracker/data/TrackMocks.java
+++ b/app/src/test/java/net/osmtracker/data/TrackMocks.java
@@ -1,0 +1,47 @@
+package net.osmtracker.data;
+
+import net.osmtracker.db.model.Track;
+
+public class TrackMocks {
+
+    // TrackId for mock Track to generate file real-track.gpx
+    public static final long GPX_TRACKID = 7l;
+
+
+    /**
+     * This track matches the data of real-track.gpx
+     *
+     * @return Track
+     */
+    public static Track getMockTrackForGPX() {
+        Track track = new Track();
+        track.setTrackId(GPX_TRACKID);
+        track.setName("2020-12-30_17-20-17");
+        track.setDescription(null);
+        track.setTags("osmtracker");
+        track.setVisibility(Track.OSMVisibility.valueOf("Private"));
+        track.setStartDate(1609370417227l);
+        //TODO: check why TrackDate is used as startDate in Track.build)()
+        track.setTrackDate(1609370417227l);
+
+        track.setTpCount(TrackPointMocks.GPX_TRACKPOINTS_COUNT);
+        track.setWpCount(WayPointMocks.GPX_WAYPOINTS_COUNT);
+
+        return track;
+    }
+
+
+    /**
+     *
+     * @param trackName
+     * @param trackStartDate
+     * @return
+     */
+    public static Track createMockTrack(String trackName, long trackStartDate) {
+        Track track = new Track();
+        track.setName(trackName);
+        track.setStartDate(trackStartDate);
+        return track;
+    }
+
+}

--- a/app/src/test/java/net/osmtracker/data/TrackMocks.java
+++ b/app/src/test/java/net/osmtracker/data/TrackMocks.java
@@ -4,12 +4,12 @@ import net.osmtracker.db.model.Track;
 
 public class TrackMocks {
 
-    // TrackId for mock Track to generate file real-track.gpx
+    // TrackId for mock Track used in ExportTrackTest.testWriteGPXFile()
     public static final long GPX_TRACKID = 7l;
 
 
     /**
-     * This track matches the data of real-track.gpx
+     * Matches data of gpx-test.gpx used in ExportTrackTest.testWriteGPXFile()
      *
      * @return Track
      */

--- a/app/src/test/java/net/osmtracker/data/TrackPointMocks.java
+++ b/app/src/test/java/net/osmtracker/data/TrackPointMocks.java
@@ -1,15 +1,36 @@
 package net.osmtracker.data;
 
 import net.osmtracker.db.model.TrackPoint;
-import net.osmtracker.db.model.WayPoint;
 
 public class TrackPointMocks {
 
-    // TrackPoints of real-track.gpx
+    // TrackPoints of gpx-test.gpx
     static final int GPX_TRACKPOINTS_COUNT = 2;
 
-    //
+    //hdop = false, compass = none
     public static String MOCK_TRACKPOINT_XML_A =
+            "\t\t\t<trkpt lat=\"10.037569043664794\" lon=\"-84.21228868248848\">\n"
+                    +"\t\t\t\t<ele>1015.1315925326198</ele>\n"
+                    +"\t\t\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<speed>0.3619388937950134</speed>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t\t\t</trkpt>\n";
+
+    //hdop = false, compass = comment
+    public static String MOCK_TRACKPOINT_XML_B =
+            "\t\t\t<trkpt lat=\"10.037569043664794\" lon=\"-84.21228868248848\">\n"
+                    +"\t\t\t\t<ele>1015.1315925326198</ele>\n"
+                    +"\t\t\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t\t\t<cmt><![CDATA[compass: 204.690002441406\n"
+                    +"\t\t\t\t\tcompAccuracy: 2.0]]></cmt>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<speed>0.3619388937950134</speed>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t\t\t</trkpt>\n";
+
+    //hdop = false, compass = extension
+    public static String MOCK_TRACKPOINT_XML_C =
             "\t\t\t<trkpt lat=\"10.037569043664794\" lon=\"-84.21228868248848\">\n"
                     +"\t\t\t\t<ele>1015.1315925326198</ele>\n"
                     +"\t\t\t\t<time>2001-05-16T23:20:28Z</time>\n"
@@ -20,6 +41,55 @@ public class TrackPointMocks {
                     +"\t\t\t\t</extensions>\n"
                     +"\t\t\t</trkpt>\n";
 
+    //hdop = true, compass = none
+    public static String MOCK_TRACKPOINT_XML_D =
+            "\t\t\t<trkpt lat=\"10.037569043664794\" lon=\"-84.21228868248848\">\n"
+                    +"\t\t\t\t<ele>1015.1315925326198</ele>\n"
+                    +"\t\t\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t\t\t<hdop>10.0</hdop>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<speed>0.3619388937950134</speed>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t\t\t</trkpt>\n";
+
+    //hdop = true, compass = comment
+    public static String MOCK_TRACKPOINT_XML_E =
+            "\t\t\t<trkpt lat=\"10.037569043664794\" lon=\"-84.21228868248848\">\n"
+                    +"\t\t\t\t<ele>1015.1315925326198</ele>\n"
+                    +"\t\t\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t\t\t<hdop>10.0</hdop>\n"
+                    +"\t\t\t\t<cmt><![CDATA[compass: 204.690002441406\n"
+                    +"\t\t\t\t\tcompAccuracy: 2.0]]></cmt>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<speed>0.3619388937950134</speed>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t\t\t</trkpt>\n";
+
+    //hdop = true, compass = extension
+    public static String MOCK_TRACKPOINT_XML_F =
+            "\t\t\t<trkpt lat=\"10.037569043664794\" lon=\"-84.21228868248848\">\n"
+                    +"\t\t\t\t<ele>1015.1315925326198</ele>\n"
+                    +"\t\t\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t\t\t<hdop>10.0</hdop>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<speed>0.3619388937950134</speed>\n"
+                    +"\t\t\t\t\t<compass>204.690002441406</compass>\n"
+                    +"\t\t\t\t\t<compass_accuracy>2.0</compass_accuracy>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t\t\t</trkpt>\n";
+
+    //hdop = true, compass = none
+    //trkpt.Accuracy = null
+    public static String MOCK_TRACKPOINT_XML_G =
+            "\t\t\t<trkpt lat=\"10.037569043664794\" lon=\"-84.21228868248848\">\n"
+                    +"\t\t\t\t<ele>1015.1315925326198</ele>\n"
+                    +"\t\t\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<speed>0.3619388937950134</speed>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t\t\t</trkpt>\n";
+
+
     public static TrackPoint getMockTrackPointForXML(){
         TrackPoint trkpt = new TrackPoint();
         trkpt.setId(3);
@@ -28,7 +98,7 @@ public class TrackPointMocks {
         trkpt.setLongitude(-84.21228868248848);
         trkpt.setSpeed(0.3619388937950134);
         trkpt.setElevation(1015.1315925326198);
-        trkpt.setAccuracy(null);
+        trkpt.setAccuracy(40.0);
         trkpt.setPointTimestamp(990055228011l);
         trkpt.setCompassHeading(204.690002441406);
         trkpt.setCompassAccuracy(2.0d);
@@ -37,7 +107,7 @@ public class TrackPointMocks {
     }
 
     /**
-     * This trackPoints match the data of real-track.gpx
+     * Matches data of gpx-test.gpx used in ExportTrackTest.testWriteGPXFile()
      *
      * @param trkptId
      * @return

--- a/app/src/test/java/net/osmtracker/data/TrackPointMocks.java
+++ b/app/src/test/java/net/osmtracker/data/TrackPointMocks.java
@@ -1,0 +1,73 @@
+package net.osmtracker.data;
+
+import net.osmtracker.db.model.TrackPoint;
+import net.osmtracker.db.model.WayPoint;
+
+public class TrackPointMocks {
+
+    // TrackPoints of real-track.gpx
+    static final int GPX_TRACKPOINTS_COUNT = 2;
+
+    //
+    public static String MOCK_TRACKPOINT_XML_A =
+            "\t\t\t<trkpt lat=\"10.037569043664794\" lon=\"-84.21228868248848\">\n"
+                    +"\t\t\t\t<ele>1015.1315925326198</ele>\n"
+                    +"\t\t\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<speed>0.3619388937950134</speed>\n"
+                    +"\t\t\t\t\t<compass>204.690002441406</compass>\n"
+                    +"\t\t\t\t\t<compass_accuracy>2.0</compass_accuracy>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t\t\t</trkpt>\n";
+
+    public static TrackPoint getMockTrackPointForXML(){
+        TrackPoint trkpt = new TrackPoint();
+        trkpt.setId(3);
+        trkpt.setTrackId(7);
+        trkpt.setLatitude(10.037569043664794);
+        trkpt.setLongitude(-84.21228868248848);
+        trkpt.setSpeed(0.3619388937950134);
+        trkpt.setElevation(1015.1315925326198);
+        trkpt.setAccuracy(null);
+        trkpt.setPointTimestamp(990055228011l);
+        trkpt.setCompassHeading(204.690002441406);
+        trkpt.setCompassAccuracy(2.0d);
+        trkpt.setAtmosphericPressure(null);
+        return trkpt;
+    }
+
+    /**
+     * This trackPoints match the data of real-track.gpx
+     *
+     * @param trkptId
+     * @return
+     */
+    public static TrackPoint getMockTrackPointForGPX(Integer trkptId) {
+        TrackPoint trkpt = new TrackPoint();
+        trkpt.setId(trkptId);
+        trkpt.setTrackId(7);
+
+        if (trkptId == 1) {
+            trkpt.setLatitude(10.0375690436648);
+            trkpt.setLongitude(-84.2122886824885);
+            trkpt.setSpeed(0.361938893795013);
+            trkpt.setElevation(1015.13159253262);
+            trkpt.setAccuracy(35.635440826416);
+            trkpt.setPointTimestamp(990055225811l);
+            trkpt.setCompassHeading(204.690002441406);
+            trkpt.setCompassAccuracy(2d);
+        } else if (trkptId == 2) {
+            trkpt.setLatitude(10.0377106969496);
+            trkpt.setLongitude(-84.2123268390527);
+            trkpt.setSpeed(0.271533757448196);
+            trkpt.setElevation(1007.3209409276);
+            trkpt.setAccuracy(52.0706405639648);
+            trkpt.setPointTimestamp(990055226011l);
+            trkpt.setCompassHeading(204.360000610352);
+            trkpt.setCompassAccuracy(2d);
+        }
+        trkpt.setAtmosphericPressure(null);
+
+        return trkpt;
+    }
+}

--- a/app/src/test/java/net/osmtracker/data/WayPointMocks.java
+++ b/app/src/test/java/net/osmtracker/data/WayPointMocks.java
@@ -3,12 +3,16 @@ package net.osmtracker.data;
 
 import net.osmtracker.db.model.WayPoint;
 
+import java.util.Date;
+
+import static net.osmtracker.util.UnitTestUtils.createDateFrom;
+
 public class WayPointMocks {
 
-    // WayPoints of real-track.gpx
+    // WayPoints of gpx-test.gpx
     static final int GPX_WAYPOINTS_COUNT = 1;
 
-    //compass = none, accuracy= none.
+    //compass = none, accuracy = none. hdop = false
     public static String MOCK_WAYPOINT_XML_A =
             "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
                     +"\t\t<ele>1073.3167528454214</ele>\n"
@@ -17,16 +21,249 @@ public class WayPointMocks {
                     +"\t\t<sat>0</sat>\n"
                     +"\t</wpt>\n";
 
+    //compass = none, accuracy = name. hdop = false
+    public static String MOCK_WAYPOINT_XML_B =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto (24.0m)]]></name>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t</wpt>\n";
+
+    //compass = none, accuracy = comment. hdop = false
+    public static String MOCK_WAYPOINT_XML_C =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<cmt><![CDATA[Precisión: 24.0m]]></cmt>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t</wpt>\n";
+
+    //compass = comment, accuracy = none. hdop = false
+    public static String MOCK_WAYPOINT_XML_D =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<cmt><![CDATA[compass heading: 271.4599914550781deg\n"
+                    +"\t\t\tcompass accuracy: 2.0]]></cmt>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t</wpt>\n";
+
+    //compass = comment, accuracy = name. hdop = false
+    public static String MOCK_WAYPOINT_XML_E =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto (24.0m)]]></name>\n"
+                    +"\t\t<cmt><![CDATA[compass heading: 271.4599914550781deg\n"
+                    +"\t\t\tcompass accuracy: 2.0]]></cmt>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t</wpt>\n";
+
+    //compass = comment, accuracy = comment. hdop = false
+    public static String MOCK_WAYPOINT_XML_F =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<cmt><![CDATA[Precisión: 24.0m\n"
+                    +"\t\t\tcompass heading: 271.4599914550781deg\n"
+                    +"\t\t\tcompass accuracy: 2.0]]></cmt>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t</wpt>\n";
+
+    //compass = extension, accuracy = none. hdop = false
+    public static String MOCK_WAYPOINT_XML_G =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<compass>271.4599914550781</compass>\n"
+                    +"\t\t\t\t\t<compass_accuracy>2.0</compass_accuracy>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t</wpt>\n";
+
+    //compass = extension, accuracy = name. hdop = false
+    public static String MOCK_WAYPOINT_XML_H =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto (24.0m)]]></name>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<compass>271.4599914550781</compass>\n"
+                    +"\t\t\t\t\t<compass_accuracy>2.0</compass_accuracy>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t</wpt>\n";
+
+    //compass = extension, accuracy = comment. hdop = false
+    public static String MOCK_WAYPOINT_XML_I =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<cmt><![CDATA[Precisión: 24.0m]]></cmt>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<compass>271.4599914550781</compass>\n"
+                    +"\t\t\t\t\t<compass_accuracy>2.0</compass_accuracy>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t</wpt>\n";
+
+    //compass = none, accuracy = none. hdop = true
+    public static String MOCK_WAYPOINT_XML_J =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t<hdop>6.0</hdop>\n"
+                    +"\t</wpt>\n";
+
+    //compass = none, accuracy = name. hdop = true
+    public static String MOCK_WAYPOINT_XML_K =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto (24.0m)]]></name>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t<hdop>6.0</hdop>\n"
+                    +"\t</wpt>\n";
+
+    //compass = none, accuracy = comment. hdop = true
+    public static String MOCK_WAYPOINT_XML_L =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<cmt><![CDATA[Precisión: 24.0m]]></cmt>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t<hdop>6.0</hdop>\n"
+                    +"\t</wpt>\n";
+
+    //compass = comment, accuracy = none. hdop = true
+    public static String MOCK_WAYPOINT_XML_M =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<cmt><![CDATA[compass heading: 271.4599914550781deg\n"
+                    +"\t\t\tcompass accuracy: 2.0]]></cmt>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t<hdop>6.0</hdop>\n"
+                    +"\t</wpt>\n";
+
+    //compass = comment, accuracy = name. hdop = true
+    public static String MOCK_WAYPOINT_XML_N =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto (24.0m)]]></name>\n"
+                    +"\t\t<cmt><![CDATA[compass heading: 271.4599914550781deg\n"
+                    +"\t\t\tcompass accuracy: 2.0]]></cmt>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t<hdop>6.0</hdop>\n"
+                    +"\t</wpt>\n";
+
+    //compass = comment, accuracy = comment. hdop = true
+    public static String MOCK_WAYPOINT_XML_O =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<cmt><![CDATA[Precisión: 24.0m\n"
+                    +"\t\t\tcompass heading: 271.4599914550781deg\n"
+                    +"\t\t\tcompass accuracy: 2.0]]></cmt>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t<hdop>6.0</hdop>\n"
+                    +"\t</wpt>\n";
+
+    //compass = extension, accuracy = none.  hdop = true
+    public static String MOCK_WAYPOINT_XML_P =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t<hdop>6.0</hdop>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<compass>271.4599914550781</compass>\n"
+                    +"\t\t\t\t\t<compass_accuracy>2.0</compass_accuracy>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t</wpt>\n";
+
+    //compass = extension, accuracy = name. hdop = true
+    public static String MOCK_WAYPOINT_XML_Q =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto (24.0m)]]></name>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t<hdop>6.0</hdop>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<compass>271.4599914550781</compass>\n"
+                    +"\t\t\t\t\t<compass_accuracy>2.0</compass_accuracy>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t</wpt>\n";
+
+    //compass = extension, accuracy = comment. hdop = true
+    public static String MOCK_WAYPOINT_XML_R =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<cmt><![CDATA[Precisión: 24.0m]]></cmt>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t<hdop>6.0</hdop>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<compass>271.4599914550781</compass>\n"
+                    +"\t\t\t\t\t<compass_accuracy>2.0</compass_accuracy>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t</wpt>\n";
+
+    //compass = extension, accuracy = comment. hdop = true
+    //wpt.accuracy == null and wpt.atmosphericPressure == 5.54321
+    public static String MOCK_WAYPOINT_XML_S =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<compass>271.4599914550781</compass>\n"
+                    +"\t\t\t\t\t<compass_accuracy>2.0</compass_accuracy>\n"
+                    +"\t\t\t\t\t<baro>5.5</baro>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t</wpt>\n";
+
+    //compass = extension, accuracy = comment. hdop = true
+    //wpt.accuracy == null, wpt.atmosphericPressure == 5.54321, wpt.compassHeading == null
+    // (but wpt.compassAccuracy != null)
+    public static String MOCK_WAYPOINT_XML_T =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t\t\t\t<extensions>\n"
+                    +"\t\t\t\t\t<baro>5.5</baro>\n"
+                    +"\t\t\t\t</extensions>\n"
+                    +"\t</wpt>\n";
+
     public static WayPoint getMockWayPointForXML(){
         WayPoint wpt = new WayPoint();
         wpt.setLatitude(10.037578304829676);
         wpt.setLongitude(-84.21210085275517);
         wpt.setElevation(1073.3167528454214);
-        wpt.setPointTimestamp(990055228011l);
+        wpt.setPointTimestamp(990055228011l); //2001-05-16T23:20:28Z
         wpt.setName("Nota de texto");
-        wpt.setAccuracy(0.0);
-        wpt.setCompassHeading(0.0);
-        wpt.setCompassHeading(0.0);
+        wpt.setAccuracy(24.0);
+        wpt.setCompassHeading(271.4599914550781);
+        wpt.setCompassAccuracy(2.0);
         wpt.setLink(null);
         wpt.setNumberOfSatellites(0);
         wpt.setAtmosphericPressure(null);
@@ -34,7 +271,7 @@ public class WayPointMocks {
     }
 
     /**
-     * This wayPoint matche data of real-track.gpx
+     * Matches data of gpx-test.gpx used in ExportTrackTest.testWriteGPXFile()
      *
      * @param wptId
      * @return

--- a/app/src/test/java/net/osmtracker/data/WayPointMocks.java
+++ b/app/src/test/java/net/osmtracker/data/WayPointMocks.java
@@ -1,0 +1,63 @@
+package net.osmtracker.data;
+
+
+import net.osmtracker.db.model.WayPoint;
+
+public class WayPointMocks {
+
+    // WayPoints of real-track.gpx
+    static final int GPX_WAYPOINTS_COUNT = 1;
+
+    //compass = none, accuracy= none.
+    public static String MOCK_WAYPOINT_XML_A =
+            "\t<wpt lat=\"10.037578304829676\" lon=\"-84.21210085275517\">\n"
+                    +"\t\t<ele>1073.3167528454214</ele>\n"
+                    +"\t\t<time>2001-05-16T23:20:28Z</time>\n"
+                    +"\t\t<name><![CDATA[Nota de texto]]></name>\n"
+                    +"\t\t<sat>0</sat>\n"
+                    +"\t</wpt>\n";
+
+    public static WayPoint getMockWayPointForXML(){
+        WayPoint wpt = new WayPoint();
+        wpt.setLatitude(10.037578304829676);
+        wpt.setLongitude(-84.21210085275517);
+        wpt.setElevation(1073.3167528454214);
+        wpt.setPointTimestamp(990055228011l);
+        wpt.setName("Nota de texto");
+        wpt.setAccuracy(0.0);
+        wpt.setCompassHeading(0.0);
+        wpt.setCompassHeading(0.0);
+        wpt.setLink(null);
+        wpt.setNumberOfSatellites(0);
+        wpt.setAtmosphericPressure(null);
+        return wpt;
+    }
+
+    /**
+     * This wayPoint matche data of real-track.gpx
+     *
+     * @param wptId
+     * @return
+     */
+    public static WayPoint getMockWayPointForGPX(Integer wptId) {
+        WayPoint wpt = new WayPoint();
+
+        wpt.setId(wptId);
+        wpt.setTrackId(7);
+        wpt.setUuid("2681b418-d6c6-4f7a-baf2-7c24a2a274b7");
+        wpt.setLatitude(10.0375634848231);
+        wpt.setLongitude(-84.2123549868801);
+        wpt.setElevation(1029.89940680377);
+        wpt.setAccuracy(24.0);
+        wpt.setPointTimestamp(990055228011l);
+        wpt.setName("Punto de prueba");
+        wpt.setLink(null);
+        wpt.setNumberOfSatellites(0);
+        wpt.setCompassHeading(204.029998779297);
+        wpt.setCompassAccuracy(2d);
+        wpt.setAtmosphericPressure(null);
+
+        return wpt;
+    }
+
+}

--- a/app/src/test/java/net/osmtracker/gpx/ExportTrackTest.java
+++ b/app/src/test/java/net/osmtracker/gpx/ExportTrackTest.java
@@ -5,15 +5,19 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.preference.PreferenceManager;
 
+import net.osmtracker.OSMTracker;
 import net.osmtracker.R;
 import net.osmtracker.data.GPXMocks;
+import net.osmtracker.data.MockDataHelper;
 import net.osmtracker.data.TrackMocks;
 import net.osmtracker.data.TrackPointMocks;
 import net.osmtracker.data.WayPointMocks;
+import net.osmtracker.db.DataHelper;
 import net.osmtracker.db.model.Track;
 import net.osmtracker.db.model.TrackPoint;
 import net.osmtracker.db.model.WayPoint;
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -22,6 +26,7 @@ import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import java.io.File;
 import java.util.Date;
 
 import static junit.framework.TestCase.assertEquals;
@@ -35,9 +40,7 @@ import static net.osmtracker.OSMTracker.Preferences;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ PreferenceManager.class })
-//@PrepareForTest({ PreferenceManager.class, Environment.class, ExportTrackTask.class,
-//        ExportToStorageTask.class})
+@PrepareForTest({ PreferenceManager.class, ExportTrackTask.class })
 public class ExportTrackTest {
 
     @Rule
@@ -147,6 +150,46 @@ public class ExportTrackTest {
         when(PreferenceManager.getDefaultSharedPreferences(mockContext)).thenReturn(mockPrefs);
     }
 
+
+    @Test
+    public void testWriteGPXFile() throws Exception {
+
+        // Mock preferences
+        SharedPreferences mockPrefs = mock(SharedPreferences.class);
+
+        when(mockPrefs.getString(OSMTracker.Preferences.KEY_OUTPUT_ACCURACY,
+                OSMTracker.Preferences.VAL_OUTPUT_ACCURACY)).thenReturn("none");
+        when(mockPrefs.getBoolean(OSMTracker.Preferences.KEY_OUTPUT_GPX_HDOP_APPROXIMATION,
+                OSMTracker.Preferences.VAL_OUTPUT_GPX_HDOP_APPROXIMATION)).thenReturn(true);
+        when(mockPrefs.getString(OSMTracker.Preferences.KEY_OUTPUT_COMPASS,
+                OSMTracker.Preferences.VAL_OUTPUT_COMPASS)).thenReturn("extension");
+        mockStatic(PreferenceManager.class);
+        when(PreferenceManager.getDefaultSharedPreferences(mockContext)).thenReturn(mockPrefs);
+
+        // Setup the mock resources
+        Resources mockResources = mock(Resources.class);
+        when(mockResources.getString(R.string.various_unit_meters)).thenReturn("m");
+        when(mockResources.getString(R.string.gpx_track_name))
+                .thenReturn("Trazado con OSMTracker para Android™");
+        when(mockResources.getString(R.string.gpx_hdop_approximation_cmt))
+                .thenReturn("Advertencia: los valores HDOP no son los valores HDOP devueltos por el"
+                        + " dispositivo GPS. Son valores aproximados de acuerdo a la precisión de"
+                        + " la ubicación en metros.");
+        when(mockContext.getResources()).thenReturn(mockResources);
+
+        Track track = TrackMocks.getMockTrackForGPX();
+        File resultGPX = new File("./src/test/assets/gpx/output-test.gpx");
+        ExportTrackTask task = new ExportToStorageTask(mockContext, TrackMocks.GPX_TRACKID);
+
+        DataHelper dhMock = new MockDataHelper(mockContext);
+        whenNew(DataHelper.class).withAnyArguments().thenReturn(dhMock);
+
+        task.writeGpxFile(track, resultGPX);
+        File expectedGPX = new File("./src/test/assets/gpx/gpx-test.gpx");
+        assertEquals(true, FileUtils.contentEquals(resultGPX, expectedGPX));
+
+    }
+
     @Test
     public void testBuildMetadataString() {
         Track track = TrackMocks.createMockTrack("Nombre de la traza",
@@ -156,15 +199,22 @@ public class ExportTrackTest {
 
         ExportTrackTask task = new ExportToStorageTask(mockContext, 3);
         String result = task.buildMetadataString(track);
-        assertEquals(GPXMocks.MOCK_WAYPOINT_XML_A, result);
+        assertEquals(GPXMocks.MOCK_METADATA_XML_A, result);
 
     }
 
     @Test
     public void testBuildTrackPointString() {
         TrackPoint trkpt = TrackPointMocks.getMockTrackPointForXML();
-        boolean fillHDOP = false;
-        String compass = "extension";
+        String result;
+        boolean fillHDOP;
+        String[] compassValues = {"none", "comment", "extension"};
+        String[] expectedResults = {TrackPointMocks.MOCK_TRACKPOINT_XML_A,
+                TrackPointMocks.MOCK_TRACKPOINT_XML_B, TrackPointMocks.MOCK_TRACKPOINT_XML_C,
+                TrackPointMocks.MOCK_TRACKPOINT_XML_D, TrackPointMocks.MOCK_TRACKPOINT_XML_E,
+                TrackPointMocks.MOCK_TRACKPOINT_XML_F, TrackPointMocks.MOCK_TRACKPOINT_XML_G
+        };
+        int expectedResultIndex= 0;
 
         // Setup the mock resources
         Resources mockResources = mock(Resources.class);
@@ -173,65 +223,93 @@ public class ExportTrackTest {
 
         ExportTrackTask task = new ExportToStorageTask(mockContext, 3);
 
-        String result = task.buildTrackPointString(trkpt, fillHDOP, compass);
-        assertEquals(TrackPointMocks.MOCK_TRACKPOINT_XML_A, result);
+        fillHDOP = false;
+        for (String compass : compassValues) {
+            result = task.buildTrackPointString(trkpt, fillHDOP, compass);
+            assertEquals(expectedResults[expectedResultIndex], result);
+            expectedResultIndex = expectedResultIndex + 1;
+        }
+        fillHDOP = true;
+        for (String compass : compassValues) {
+            result = task.buildTrackPointString(trkpt, fillHDOP, compass);
+            assertEquals(expectedResults[expectedResultIndex], result);
+            expectedResultIndex = expectedResultIndex + 1;
+        }
+
+        //hdop = true, compass = none and trkpt.Accuracy = null
+        trkpt.setAccuracy(null);
+        result = task.buildTrackPointString(trkpt, true, "none");
+        assertEquals(expectedResults[expectedResultIndex], result);
+
+
     }
 
 
     @Test
     public void testBuildWayPointString() {
         WayPoint wpt = WayPointMocks.getMockWayPointForXML();
-        String accuracyInfo = "none";
-        boolean fillHDOP = false;
-        String compass = "none";
+        String result;
+        boolean fillHDOP;
+        String[] accuracyInfoValues = {"none", "wpt_name", "wpt_cmt"};
+        String[] compassValues = {"none", "comment", "extension"};
+        String[] expectedResults = {WayPointMocks.MOCK_WAYPOINT_XML_A,
+                WayPointMocks.MOCK_WAYPOINT_XML_B, WayPointMocks.MOCK_WAYPOINT_XML_C,
+                WayPointMocks.MOCK_WAYPOINT_XML_D, WayPointMocks.MOCK_WAYPOINT_XML_E,
+                WayPointMocks.MOCK_WAYPOINT_XML_F, WayPointMocks.MOCK_WAYPOINT_XML_G,
+                WayPointMocks.MOCK_WAYPOINT_XML_H, WayPointMocks.MOCK_WAYPOINT_XML_I,
+                WayPointMocks.MOCK_WAYPOINT_XML_J, WayPointMocks.MOCK_WAYPOINT_XML_K,
+                WayPointMocks.MOCK_WAYPOINT_XML_L, WayPointMocks.MOCK_WAYPOINT_XML_M,
+                WayPointMocks.MOCK_WAYPOINT_XML_N, WayPointMocks.MOCK_WAYPOINT_XML_O,
+                WayPointMocks.MOCK_WAYPOINT_XML_P, WayPointMocks.MOCK_WAYPOINT_XML_Q,
+                WayPointMocks.MOCK_WAYPOINT_XML_R
+        };
+        int expectedResultIndex= 0;
 
         // Setup the mock resources
         Resources mockResources = mock(Resources.class);
         when(mockResources.getString(R.string.various_unit_meters)).thenReturn("m");
+        when(mockResources.getString(R.string.various_accuracy)).thenReturn("Precisión");
         when(mockContext.getResources()).thenReturn(mockResources);
 
         ExportTrackTask task = new ExportToStorageTask(mockContext, 3);
 
-        String result = task.buildWayPointString(wpt, accuracyInfo, fillHDOP, compass);
-        assertEquals(WayPointMocks.MOCK_WAYPOINT_XML_A, result);
+        fillHDOP = false;
+        for (String compass : compassValues) {
+            for (String accuracyInfo : accuracyInfoValues) {
+                //System.out.println("buildWayPointString with " + accuracyInfo  + " "
+                //        + fillHDOP + " " + compass);
+                result = task.buildWayPointString(wpt, accuracyInfo, fillHDOP, compass);
+                assertEquals(expectedResults[expectedResultIndex], result);
+                expectedResultIndex = expectedResultIndex + 1;
+            }
+        }
+        fillHDOP = true;
+        for (String compass : compassValues) {
+            for (String accuracyInfo : accuracyInfoValues) {
+                //System.out.println("buildWayPointString with " + accuracyInfo  + " "
+                //        + fillHDOP + " " + compass);
+                result = task.buildWayPointString(wpt, accuracyInfo, fillHDOP, compass);
+                assertEquals(expectedResults[expectedResultIndex], result);
+                expectedResultIndex = expectedResultIndex + 1;
+            }
+        }
+
+        //compass = extension, accuracy = comment. hdop = true
+        //wpt.accuracy == null and wpt.atmosphericPressure == 5.54321
+        wpt.setAccuracy(null);
+        wpt.setAtmosphericPressure(5.54321);
+        //wpt.setCompassHeading(null);
+        result = task.buildWayPointString(wpt, "comment", true,
+                "extension");
+        assertEquals(WayPointMocks.MOCK_WAYPOINT_XML_S, result);
+
+        //compass = extension, accuracy = comment. hdop = true
+        //wpt.accuracy == null, wpt.atmosphericPressure == 5.54321, wpt.compassHeading == null
+        // (but wpt.compassAccuracy != null)
+        wpt.setCompassHeading(null);
+        result = task.buildWayPointString(wpt, "comment", true,
+                "extension");
+        assertEquals(WayPointMocks.MOCK_WAYPOINT_XML_T, result);
     }
-
-    /**
-    @Test
-    public void testExportTrackAsGpx()  throws Exception {
-        mockStatic(Environment.class);
-        when(Environment.getExternalStorageState()).thenReturn(Environment.MEDIA_MOUNTED);
-        File testStorageDirectory = new File("./src/test/assets/gpx/");
-        when(Environment.getExternalStorageDirectory()).thenReturn(testStorageDirectory);
-
-        // Mock preferences
-        SharedPreferences mockPrefs = mock(SharedPreferences.class);
-        // gpx output dir per track.
-        when(mockPrefs.getBoolean(OSMTracker.Preferences.KEY_OUTPUT_DIR_PER_TRACK,
-                OSMTracker.Preferences.VAL_OUTPUT_GPX_OUTPUT_DIR_PER_TRACK)).thenReturn(true);
-        when(mockPrefs.getString(OSMTracker.Preferences.KEY_STORAGE_DIR,
-                OSMTracker.Preferences.VAL_STORAGE_DIR)).thenReturn("/osmtracker-test");
-        when(mockPrefs.getString(OSMTracker.Preferences.KEY_OUTPUT_FILENAME,
-                OSMTracker.Preferences.VAL_OUTPUT_FILENAME)).thenReturn("name_date");
-        mockStatic(PreferenceManager.class);
-        when(PreferenceManager.getDefaultSharedPreferences(mockContext)).thenReturn(mockPrefs);
-
-        // Setup the mock resources
-        Resources mockResources = mock(Resources.class);
-        when(mockResources.getString(R.string.various_unit_meters)).thenReturn("m");
-        when(mockContext.getResources()).thenReturn(mockResources);
-
-        DataHelper dhMock = new MockDataHelper(mockContext);
-        whenNew(DataHelper.class).withAnyArguments().thenReturn(dhMock);
-
-
-        long trackId = TrackMocks.GPX_TEST_TRACKID;
-        ExportTrackTask task = new ExportToStorageTask(mockContext, trackId);
-        File outputGPX = task.exportTrackAsGpx(trackId);
-
-        File expectedGPX = new File("./src/test/assets/gpx/real-track.gpx");
-        assertEquals(true, FileUtils.contentEquals(outputGPX, expectedGPX));
-    }
-    */
 
 }

--- a/app/src/test/java/net/osmtracker/test/db/model/TrackTest.java
+++ b/app/src/test/java/net/osmtracker/test/db/model/TrackTest.java
@@ -2,15 +2,12 @@ package net.osmtracker.test.db.model;
 
 import android.content.ContentResolver;
 import android.database.Cursor;
-import android.opengl.Visibility;
 
 import net.osmtracker.db.TrackContentProvider;
 import net.osmtracker.db.model.Track;
 import static net.osmtracker.db.TrackContentProvider.Schema.*;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;


### PR DESCRIPTION
The main goal of this PR is to simplify the way GPX files are created, to make easier introducing unit tests and make the code more legible for promote more users collaboration. 

This PR includes a refactor of `ExportTrackTask` and adds junit tests in `ExportTrackTaskTest`. Access to DB or content provider was encapsulated in `DataHelper` for net.osmtracker.gpx package, model objects (net.osmtracker.db.model.*) are passed as result of the queries. 

Minor changes:

 * `TrackDetailEditor`, `TrackListAdapter`: change in method name.
* `main/res/xml/preferences.xml`: change in indentation of `ListPreference` element in favor of legibility.

Also this PR uniforms the way compass values are exported to the GPX File in a *comment*, they are now written with the format:

~~~
<cmt><![CDATA[compass heading: --VALUE--deg
		compass accuracy: --VALUE--]]></cmt>
~~~

Example:

~~~
<cmt><![CDATA[compass heading: 271.4599914550781deg
   	      compass accuracy: 2.0]]></cmt>		
~~~

Prior this PR the format depending of the way the *accuracy* was exported.

Closes: #274 