### PR TITLE
Updating the target SDK to 35 with the necessary changes in dependencies, permissions and execution flows

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ apply plugin: 'kotlin-android-extensions'
 android {
 
     useLibrary 'org.apache.http.legacy'
-    compileSdk 33
+    compileSdk 35
 
     defaultConfig {
         applicationId "net.osmtracker"
         minSdkVersion 25
-        targetSdkVersion 33
+        targetSdkVersion 35
         multiDexEnabled true
 
         testApplicationId "net.osmtracker.test"
@@ -77,7 +77,7 @@ dependencies {
     //implementation 'oauth.signpost:signpost-commonshttp4:1.2.1.2'
     implementation 'org.slf4j:slf4j-android:1.7.30'
     implementation 'androidx.core:core:1.6.0'
-    //implementation 'org.apache.commons:commons-io:1.3.2'
+    implementation 'org.apache.commons:commons-io:1.3.2'
 
     // For upload traces to osm server
     implementation 'net.openid:appauth:0.11.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
 
     <!-- Foreground services and network permissions -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/app/src/main/java/net/osmtracker/activity/Preferences.java
+++ b/app/src/main/java/net/osmtracker/activity/Preferences.java
@@ -68,6 +68,16 @@ public class Preferences extends PreferenceActivity {
 		// and register a change listener to set again the summary in case of change
 		final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
 
+		// Explicit execution of buttons presets window
+		Preference buttonLayoutPref = findPreference("prefs_ui_buttons_layout");
+		if (buttonLayoutPref != null) {
+			buttonLayoutPref.setOnPreferenceClickListener(preference -> {
+				Intent intent = new Intent(this, ButtonsPresets.class);
+				startActivity(intent);
+				return true;
+			});
+		}
+
 		// External storage directory
 		EditTextPreference storageDirPref = (EditTextPreference) findPreference(OSMTracker.Preferences.KEY_STORAGE_DIR);
 		storageDirPref.setSummary(prefs.getString(OSMTracker.Preferences.KEY_STORAGE_DIR, OSMTracker.Preferences.VAL_STORAGE_DIR));

--- a/app/src/main/java/net/osmtracker/activity/TrackLogger.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackLogger.java
@@ -180,6 +180,10 @@ public class TrackLogger extends Activity {
 	 */
 	private HashSet<String> layoutNameTags = new HashSet<String>();
 
+	public boolean getButtonsEnabled() {
+		return buttonsEnabled;
+	}
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 
@@ -476,6 +480,7 @@ public class TrackLogger extends Activity {
 				saveTagsForTrack();
 
 				Intent intent = new Intent(OSMTracker.INTENT_STOP_TRACKING);
+				intent.setPackage(getPackageName());
 				sendBroadcast(intent);
 				((GpsStatusRecord) findViewById(R.id.gpsStatus)).manageRecordingIndicator(false);
 				finish();
@@ -634,6 +639,7 @@ public class TrackLogger extends Activity {
 					intent.putExtra(TrackContentProvider.Schema.COL_TRACK_ID, currentTrackId);
 					intent.putExtra(OSMTracker.INTENT_KEY_NAME, getResources().getString(R.string.wpt_stillimage));
 					intent.putExtra(OSMTracker.INTENT_KEY_LINK, imageFile.getName());
+					intent.setPackage(this.getPackageName());
 					sendBroadcast(intent);
 				}
 			}
@@ -656,6 +662,7 @@ public class TrackLogger extends Activity {
 					intent.putExtra(TrackContentProvider.Schema.COL_TRACK_ID, currentTrackId);
 					intent.putExtra(OSMTracker.INTENT_KEY_NAME, getResources().getString(R.string.wpt_stillimage));
 					intent.putExtra(OSMTracker.INTENT_KEY_LINK, imageFile.getName());
+					intent.setPackage(this.getPackageName());
 					sendBroadcast(intent);
 				}
 			}

--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -688,6 +688,7 @@ public class TrackManager extends AppCompatActivity
 		if(currentTrackId != TRACK_ID_NO_TRACK){
 			// we send a broadcast to inform all registered services to stop tracking
 			Intent intent = new Intent(OSMTracker.INTENT_STOP_TRACKING);
+			intent.setPackage(this.getPackageName());
 			sendBroadcast(intent);
 
 			// need to get sure, that the database is up to date

--- a/app/src/main/java/net/osmtracker/layout/GpsStatusRecord.java
+++ b/app/src/main/java/net/osmtracker/layout/GpsStatusRecord.java
@@ -8,6 +8,7 @@ import net.osmtracker.activity.TrackLogger;
 
 import android.Manifest;
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationListener;
@@ -132,6 +133,10 @@ public class GpsStatusRecord extends LinearLayout implements LocationListener {
 			if (!gpsActive) {
 				gpsActive = true;
 				// GPS activated, activate UI
+				activity.onGpsEnabled();
+				manageRecordingIndicator(true);
+			}
+			else if (gpsActive && !activity.getButtonsEnabled()) {
 				activity.onGpsEnabled();
 				manageRecordingIndicator(true);
 			}

--- a/app/src/main/java/net/osmtracker/listener/TagButtonOnClickListener.java
+++ b/app/src/main/java/net/osmtracker/listener/TagButtonOnClickListener.java
@@ -36,6 +36,10 @@ public class TagButtonOnClickListener implements OnClickListener {
 		Intent intent = new Intent(OSMTracker.INTENT_TRACK_WP);
 		intent.putExtra(TrackContentProvider.Schema.COL_TRACK_ID, currentTrackId);
 		intent.putExtra(OSMTracker.INTENT_KEY_NAME, label);
+
+		String packageName = view.getContext().getPackageName();
+		intent.setPackage(packageName);
+
 		view.getContext().sendBroadcast(intent);
 		
 		// Inform user that the waypoint was tracked

--- a/app/src/main/java/net/osmtracker/service/gps/GPSLogger.java
+++ b/app/src/main/java/net/osmtracker/service/gps/GPSLogger.java
@@ -222,7 +222,7 @@ public class GPSLogger extends Service implements LocationListener {
 		filter.addAction(OSMTracker.INTENT_DELETE_WP);
 		filter.addAction(OSMTracker.INTENT_START_TRACKING);
 		filter.addAction(OSMTracker.INTENT_STOP_TRACKING);
-		registerReceiver(receiver, filter);
+		registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED);
 
 		// Register ourselves for location updates
 		lmgr = (LocationManager) getSystemService(Context.LOCATION_SERVICE);

--- a/app/src/main/java/net/osmtracker/service/gps/GPSLoggerServiceConnection.java
+++ b/app/src/main/java/net/osmtracker/service/gps/GPSLoggerServiceConnection.java
@@ -50,6 +50,7 @@ public class GPSLoggerServiceConnection implements ServiceConnection {
 			activity.setEnabledActionButtons(false);
 			Intent intent = new Intent(OSMTracker.INTENT_START_TRACKING);
 			intent.putExtra(TrackContentProvider.Schema.COL_TRACK_ID, activity.getCurrentTrackId());
+			intent.setPackage(activity.getPackageName());
 			activity.sendBroadcast(intent);
 		}
 	}

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -100,7 +100,7 @@
 			android:key="ui.theme"
 			android:summary="@string/prefs_theme_summary"
 			android:defaultValue="@style/DefaultTheme" />
-		<PreferenceScreen android:title="@string/prefs_ui_buttons_layout" android:summary="@string/prefs_ui_buttons_layout_summary">
+		<PreferenceScreen android:key="prefs_ui_buttons_layout" android:title="@string/prefs_ui_buttons_layout" android:summary="@string/prefs_ui_buttons_layout_summary">
 			<intent android:action="launch_buttons_presets" />
 		</PreferenceScreen>
 		<CheckBoxPreference

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.0'
+        classpath 'com.android.tools.build:gradle:8.7.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:$kotlin_version"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
+#Mon Oct 21 08:47:26 CST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 #Mon Oct 21 08:47:26 CST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=1541fa36599e12857140465f3c91a97409b4512501c26f9631fb113e392c5bd1
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request includes changes to the project, focusing on updating the API level and adding changes necessary for proper operation after the new targetSDK. Key changes include updating the SDK versions, adding a new permission for foreground services and improving the code for button layout preferences and broadcast intents.

### Dependency and SDK Updates:
* Updated `compileSdk` and `targetSdkVersion` to 35 in `app/build.gradle`.
* Added `org.apache.commons:commons-io:1.3.2` to dependencies in `app/build.gradle`. This is for the successful execution of DownloadLayoutTest and DeleteLayoutTest.
* Upgraded Gradle distribution to `8.10.1` in `gradle-wrapper.properties`.

### Permissions:
* Added `FOREGROUND_SERVICE_LOCATION` permission in `AndroidManifest.xml`.

### Functional Enhancements:
* Added explicit execution of the buttons presets window in `Preferences.java`.
* Added `getButtonsEnabled` method in `TrackLogger.java` to know if the buttons are enabled after acquiring an accurate position fix.
* Ensured broadcast intents are set with the package name in `TrackLogger.java`, `TrackManager.java`, and `GPSLoggerServiceConnection.java`.
* Added `Context.RECEIVER_NOT_EXPORTED` flag to `registerReceiver` in `GPSLogger.java`.

### UI and Layout:
* Added `android:key` to the buttons layout preference in `preferences.xml` for explicit execution.

### Issues solved:
* #315 
* #445 