### PR TITLE
Fix #476: Resume tracking btn change the state to stopped

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -399,7 +399,9 @@ public class TrackManager extends AppCompatActivity
 
 			case R.id.trackmgr_contextmenu_resume:
 				// let's activate the track and start the TrackLogger activity
-				setActiveTrack(contextMenuSelectedTrackid);
+				if (currentTrackId == TRACK_ID_NO_TRACK) {
+					setActiveTrack(contextMenuSelectedTrackid);
+				}
 				i = new Intent(this, TrackLogger.class);
 				i.putExtra(TrackContentProvider.Schema.COL_TRACK_ID, contextMenuSelectedTrackid);
 				tryStartTrackLogger(i);

--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -396,12 +396,13 @@ public class TrackManager extends AppCompatActivity
 				// stop the active track
 				stopActiveTrack();
 				break;
-
 			case R.id.trackmgr_contextmenu_resume:
-				// let's activate the track and start the TrackLogger activity
-				if (currentTrackId == TRACK_ID_NO_TRACK) {
+				// Activate the selected track if it is different from the currently active one
+				// (or if no track is currently active)
+				if (currentTrackId != contextMenuSelectedTrackid) {
 					setActiveTrack(contextMenuSelectedTrackid);
 				}
+				// Start the TrackLogger activity to begin logging the selected track
 				i = new Intent(this, TrackLogger.class);
 				i.putExtra(TrackContentProvider.Schema.COL_TRACK_ID, contextMenuSelectedTrackid);
 				tryStartTrackLogger(i);


### PR DESCRIPTION
* Fix: #476 

The “Resume tracking” btn should execute the setActiveTrack function only when the app has no active tracking.
