### PR TITLE
Fix DividerItemDecoration duplication and GPX export issues (#479 #480)

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/TrackDetail.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackDetail.java
@@ -15,12 +15,14 @@ import net.osmtracker.gpx.ExportToStorageTask;
 import net.osmtracker.util.MercatorProjection;
 
 import android.Manifest;
+import android.app.AlertDialog;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Paint;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import androidx.core.app.ActivityCompat;
@@ -237,32 +239,10 @@ public class TrackDetail extends TrackDetailEditor implements AdapterView.OnItem
 			startActivity(i);	
 			break;
 		case R.id.trackdetail_menu_export:
-			if (ContextCompat.checkSelfPermission(this,
-					Manifest.permission.WRITE_EXTERNAL_STORAGE)  != PackageManager.PERMISSION_GRANTED) {
-
-				// Should we show an explanation?
-				if (ActivityCompat.shouldShowRequestPermissionRationale(this,
-						Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
-
-					// Show an expanation to the user *asynchronously* -- don't block
-					// this thread waiting for the user's response! After the user
-					// sees the explanation, try again to request the permission.
-					// TODO: explain why we need permission.
-					Log.w(TAG, "we should explain why we need write permission");
-
-				} else {
-
-					// No explanation needed, we can request the permission.
-					ActivityCompat.requestPermissions(this,
-							new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
-							RC_WRITE_PERMISSIONS);
-					break;
-				}
-
-			} else {
+			if (writeExternalStoragePermissionGranted()) {
 				exportTrack();
-				break;
 			}
+			break;
 		case R.id.trackdetail_menu_osm_upload:
 			i = new Intent(this, OpenStreetMapUpload.class);
 			i.putExtra(TrackContentProvider.Schema.COL_TRACK_ID, trackId);
@@ -270,6 +250,51 @@ public class TrackDetail extends TrackDetailEditor implements AdapterView.OnItem
 			break;
 		}
 		return super.onOptionsItemSelected(item);
+	}
+
+	/**
+	 * Checks if the external storage write permission is granted.
+	 * If not, it requests the permission and may display a rationale dialog explaining why it is needed.
+	 *
+	 * <p>For devices running Android R (API level 30) and above, this permission is not required,
+	 * so the method will return {@code true} immediately.</p>
+	 *
+	 * @return {@code true} if the write permission is already granted or not required (Android R+),
+	 *         {@code false} otherwise.
+	 */
+	private boolean writeExternalStoragePermissionGranted() {
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+			return true;
+		}
+		else if (ContextCompat.checkSelfPermission(this,
+						Manifest.permission.WRITE_EXTERNAL_STORAGE)  != PackageManager.PERMISSION_GRANTED) {
+			// Should we show an explanation?
+			if (ActivityCompat.shouldShowRequestPermissionRationale(this,
+							Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+				// Show an expanation to the user *asynchronously* -- don't block
+				// this thread waiting for the user's response! After the user
+				// sees the explanation, try again to request the permission.
+				new AlertDialog.Builder(this)
+								.setTitle("Permission required")
+								.setMessage("To export the GPX trace we need to write on the storage.")
+								.setPositiveButton("Accept", (dialog, which) -> {
+									// Request the permission again
+									ActivityCompat.requestPermissions(this,
+													new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+													RC_WRITE_PERMISSIONS);
+								})
+								.setNegativeButton("Cancel", (dialog, which) -> dialog.dismiss())
+								.show();
+			} else {
+				// No explanation needed, we can request the permission.
+				ActivityCompat.requestPermissions(this,
+								new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+								RC_WRITE_PERMISSIONS);
+			}
+		}
+
+		return ContextCompat.checkSelfPermission(this,
+						Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
 	}
 
 

--- a/app/src/main/java/net/osmtracker/activity/TrackDetail.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackDetail.java
@@ -275,15 +275,15 @@ public class TrackDetail extends TrackDetailEditor implements AdapterView.OnItem
 				// this thread waiting for the user's response! After the user
 				// sees the explanation, try again to request the permission.
 				new AlertDialog.Builder(this)
-								.setTitle("Permission required")
-								.setMessage("To export the GPX trace we need to write on the storage.")
-								.setPositiveButton("Accept", (dialog, which) -> {
+								.setTitle(R.string.permission_required)
+								.setMessage(R.string.storage_permission_for_export_GPX)
+								.setPositiveButton(R.string.acccept, (dialog, which) -> {
 									// Request the permission again
 									ActivityCompat.requestPermissions(this,
 													new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
 													RC_WRITE_PERMISSIONS);
 								})
-								.setNegativeButton("Cancel", (dialog, which) -> dialog.dismiss())
+								.setNegativeButton(R.string.menu_cancel, (dialog, which) -> dialog.dismiss())
 								.show();
 			} else {
 				// No explanation needed, we can request the permission.

--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -286,7 +286,7 @@ public class TrackManager extends AppCompatActivity
 			if (ActivityCompat.shouldShowRequestPermissionRationale(this,
 					Manifest.permission.ACCESS_FINE_LOCATION)) {
 				Log.i(TAG,"Should explain");
-				Toast.makeText(this, "Can't continue without GPS permission",
+				Toast.makeText(this, R.string.gps_perms_required,
 						Toast.LENGTH_LONG).show();
 			}
 
@@ -729,7 +729,7 @@ public class TrackManager extends AppCompatActivity
 					// functionality that depends on this permission.
 					//TODO: add an informative message.
 					Log.w(TAG, "we should explain why we need write permission_EXPORT_ALL");
-					Toast.makeText(this, "To export the GPX trace we need to write on the storage.", Toast.LENGTH_LONG).show();
+					Toast.makeText(this, R.string.storage_permission_for_export_GPX, Toast.LENGTH_LONG).show();
 				}
 				break;
 			}
@@ -747,7 +747,7 @@ public class TrackManager extends AppCompatActivity
 					// functionality that depends on this permission.
 					//TODO: add an informative message.
 					Log.w(TAG, "we should explain why we need write permission_EXPORT_ONE");
-					Toast.makeText(this, "To export the GPX trace we need to write on the storage.", Toast.LENGTH_LONG).show();
+					Toast.makeText(this, R.string.storage_permission_for_export_GPX, Toast.LENGTH_LONG).show();
 				}
 				break;
 			}
@@ -764,7 +764,7 @@ public class TrackManager extends AppCompatActivity
 					// functionality that depends on this permission.
 					//TODO: add an informative message.
 					Log.w(TAG, "Permission not granted");
-					Toast.makeText(this, "To display the track properly we need access to the storage.", Toast.LENGTH_LONG).show();
+					Toast.makeText(this, R.string.storage_permission_for_display_track, Toast.LENGTH_LONG).show();
 				}
 				break;
 			}
@@ -782,7 +782,7 @@ public class TrackManager extends AppCompatActivity
 					// functionality that depends on this permission.
 					//TODO: add an informative message.
 					Log.w(TAG, "Permission not granted");
-					Toast.makeText(this, "To share the track properly we need access to the storage.", Toast.LENGTH_LONG).show();
+					Toast.makeText(this, R.string.storage_permission_for_share_track, Toast.LENGTH_LONG).show();
 				}
 				break;
 			}
@@ -799,7 +799,7 @@ public class TrackManager extends AppCompatActivity
 					// functionality that depends on this permission.
 					//TODO: add an informative message.
 					Log.w(TAG, "Permission not granted");
-					Toast.makeText(this, "To upload the track to OSM we need access to the storage.", Toast.LENGTH_LONG).show();
+					Toast.makeText(this, R.string.storage_permission_for_upload_to_OSM, Toast.LENGTH_LONG).show();
 				}
 				break;
 			}

--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -84,6 +84,9 @@ public class TrackManager extends AppCompatActivity
 
 	private TrackListRVAdapter recyclerViewAdapter;
 
+	// To check if the RecyclerView already has a DividerItemDecoration added
+	private boolean hasDivider;
+
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
@@ -139,7 +142,7 @@ public class TrackManager extends AppCompatActivity
 
 
 	/**
-	 *
+	 * Configures and initializes the RecyclerView for displaying the list of tracks.
 	 */
 	private void setRecyclerView() {
 		RecyclerView recyclerView = findViewById(R.id.recyclerview);
@@ -147,11 +150,13 @@ public class TrackManager extends AppCompatActivity
 		LinearLayoutManager layoutManager = new LinearLayoutManager(this,
 				LinearLayoutManager.VERTICAL, false);
 		recyclerView.setLayoutManager(layoutManager);
-
-		DividerItemDecoration did = new DividerItemDecoration(recyclerView.getContext(),
-				layoutManager.getOrientation());
-		recyclerView.addItemDecoration(did);
-
+		// adds a divider decoration if not already present
+		if (!hasDivider) {
+			DividerItemDecoration did = new DividerItemDecoration(recyclerView.getContext(),
+					layoutManager.getOrientation());
+			recyclerView.addItemDecoration(did);
+			hasDivider = true;
+		}
 		recyclerView.setHasFixedSize(true);
 		Cursor cursor = getContentResolver().query(
 				TrackContentProvider.CONTENT_URI_TRACK, null, null, null,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -116,6 +116,15 @@
     <string name="error_voicerec_failed">Voice recording has failed</string>
     <string name="error_userlayout_parsing">Error while parsing XML layout file. Please revert to default layout.</string>
 
+    <!-- messages -->
+    <string name="permission_required">Permission required</string>
+    <string name="storage_permission_for_export_GPX">To export the GPX trace we need to write on the storage.</string>
+    <string name="storage_permission_for_display_track">To display the track properly we need access to the storage.</string>
+    <string name="storage_permission_for_share_track">To share the track properly we need access to the storage.</string>
+    <string name="storage_permission_for_upload_to_OSM">To upload the track to OSM we need access to the storage.</string>
+    <string name="acccept">Accept</string>
+    <string name="gps_perms_required">Can\'t continue without GPS permission</string>
+
     <!-- GPX -->
     <string name="gpx_track_name">Tracked with OSMTracker for Android™</string>
     <string name="gpx_hdop_approximation_cmt">Warning: HDOP values aren\'t the HDOP as returned by the GPS device. They\'re approximated from the location accuracy in meters.</string>


### PR DESCRIPTION
Hi! This PR addresses issues #479 and #480

**Modifications**
* #479 
Added a new check to prevent adding a divider multiple times.

* #480 
The request of storage permission was moved to a new private reusable method `writeExternalStoragePermissionGranted()`.
His implementation adds a new check to validate new android SDKs and a new `AlertDialog` if the permission is not granted.

---
Finally, coded strings have been replaced by @string resources to improve localization and maintenance.