### PR TITLE
Fix #333: Change exported GPX filenames to 'YYYY-MM-DD_hh-mm-ss_OSMTracker.gpx'

### DIFF
--- a/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.util.Log;
 
+import net.osmtracker.db.DataHelper;
 import net.osmtracker.exception.ExportTrackException;
 
 import java.io.File;
@@ -25,9 +26,10 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 	public ExportToTempFileTask(Context context, long trackId) {
 		super(context, trackId);
 		try {
-			tmpFile = File.createTempFile("osm-upload", ".gpx", context.getCacheDir());
+			tmpFile = new File(context.getCacheDir(), new DataHelper(context).getTrackById(trackId).getName()+"_OSMTracker.gpx");
 			Log.d(TAG, "Temporary file: " + tmpFile.getAbsolutePath());
-		} catch (IOException ioe) {
+
+		} catch (Exception ioe) {
 			Log.e(TAG, "Could not create temporary file", ioe);
 			throw new IllegalStateException("Could not create temporary file", ioe);
 		}


### PR DESCRIPTION
* This PR fixes the issue #333 

Update GPX export filenames to follow the format YYYY-MM-DD_hh-mm-ss_OSMTracker.gpx for better organization and clarity.