### PR TITLE
Customized export label for file sharing (#333, #470)

### DIFF
--- a/app/src/main/java/net/osmtracker/OSMTracker.java
+++ b/app/src/main/java/net/osmtracker/OSMTracker.java
@@ -16,6 +16,7 @@ public class OSMTracker {
 	public static final class Preferences {
 		// Property names
 		public final static String KEY_STORAGE_DIR = "logging.storage.dir";
+		public final static String KEY_EXPORT_LABEL = "gpx.export.label";
 		public final static String KEY_VOICEREC_DURATION = "voicerec.duration";
 		public final static String KEY_UI_THEME = "ui.theme";
 		public final static String KEY_GPS_OSSETTINGS = "gps.ossettings";
@@ -52,6 +53,7 @@ public class OSMTracker {
 
 		// Default values
 		public final static String VAL_STORAGE_DIR = "/osmtracker";
+		public final static String VAL_EXPORT_LABEL = "_OSMTracker";
 		public final static String VAL_VOICEREC_DURATION = "2";
 		public final static String VAL_UI_THEME = "net.osmtracker:style/DefaultTheme";
 		public final static boolean VAL_GPS_CHECKSTARTUP = true;

--- a/app/src/main/java/net/osmtracker/OSMTracker.java
+++ b/app/src/main/java/net/osmtracker/OSMTracker.java
@@ -64,6 +64,7 @@ public class OSMTracker {
 		
 		public final static String VAL_OUTPUT_FILENAME_NAME = "name";
 		public final static String VAL_OUTPUT_FILENAME_NAME_DATE = "name_date";
+		public final static String VAL_OUTPUT_FILENAME_DATE_NAME = "date_name";
 		public final static String VAL_OUTPUT_FILENAME_DATE = "date";
 		public final static String VAL_OUTPUT_FILENAME = VAL_OUTPUT_FILENAME_NAME_DATE;
 

--- a/app/src/main/java/net/osmtracker/OSMTracker.java
+++ b/app/src/main/java/net/osmtracker/OSMTracker.java
@@ -16,7 +16,6 @@ public class OSMTracker {
 	public static final class Preferences {
 		// Property names
 		public final static String KEY_STORAGE_DIR = "logging.storage.dir";
-		public final static String KEY_EXPORT_LABEL = "gpx.export.label";
 		public final static String KEY_VOICEREC_DURATION = "voicerec.duration";
 		public final static String KEY_UI_THEME = "ui.theme";
 		public final static String KEY_GPS_OSSETTINGS = "gps.ossettings";
@@ -26,6 +25,7 @@ public class OSMTracker {
 		public final static String KEY_GPS_LOGGING_MIN_DISTANCE = "gps.logging.min_distance";
 		public final static String KEY_USE_BAROMETER = "gpx.use_barometer";
 		public final static String KEY_OUTPUT_FILENAME = "gpx.filename";
+		public final static String KEY_OUTPUT_FILENAME_LABEL  = "gpx.export.label";
 		public final static String KEY_OUTPUT_ACCURACY = "gpx.accuracy";
 		public final static String KEY_OUTPUT_GPX_HDOP_APPROXIMATION = "gpx.hdop.approximation";
 		public final static String KEY_OUTPUT_DIR_PER_TRACK = "gpx.directory_per_track";
@@ -53,7 +53,6 @@ public class OSMTracker {
 
 		// Default values
 		public final static String VAL_STORAGE_DIR = "/osmtracker";
-		public final static String VAL_EXPORT_LABEL = "OSMTracker";
 		public final static String VAL_VOICEREC_DURATION = "2";
 		public final static String VAL_UI_THEME = "net.osmtracker:style/DefaultTheme";
 		public final static boolean VAL_GPS_CHECKSTARTUP = true;
@@ -63,6 +62,7 @@ public class OSMTracker {
 		public final static boolean VAL_USE_BAROMETER = false;
 		
 		public final static String VAL_OUTPUT_FILENAME_NAME = "name";
+		public final static String VAL_OUTPUT_FILENAME_LABEL = "OSMTracker";
 		public final static String VAL_OUTPUT_FILENAME_NAME_DATE = "name_date";
 		public final static String VAL_OUTPUT_FILENAME_DATE_NAME = "date_name";
 		public final static String VAL_OUTPUT_FILENAME_DATE = "date";

--- a/app/src/main/java/net/osmtracker/OSMTracker.java
+++ b/app/src/main/java/net/osmtracker/OSMTracker.java
@@ -53,7 +53,7 @@ public class OSMTracker {
 
 		// Default values
 		public final static String VAL_STORAGE_DIR = "/osmtracker";
-		public final static String VAL_EXPORT_LABEL = "_OSMTracker";
+		public final static String VAL_EXPORT_LABEL = "OSMTracker";
 		public final static String VAL_VOICEREC_DURATION = "2";
 		public final static String VAL_UI_THEME = "net.osmtracker:style/DefaultTheme";
 		public final static boolean VAL_GPS_CHECKSTARTUP = true;

--- a/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
@@ -34,7 +34,7 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 		super(context, trackId);
 		try {
 			String exportLabelName = PreferenceManager.getDefaultSharedPreferences(context).getString(
-					OSMTracker.Preferences.KEY_EXPORT_LABEL,	OSMTracker.Preferences.VAL_EXPORT_LABEL);
+					OSMTracker.Preferences.KEY_OUTPUT_FILENAME_LABEL,	OSMTracker.Preferences.VAL_OUTPUT_FILENAME_LABEL);
 			String trackName = new DataHelper(context).getTrackById(trackId).getName();
 			long date = new DataHelper(context).getTrackById(trackId).getStartDate();
 
@@ -57,15 +57,12 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 				OSMTracker.Preferences.VAL_OUTPUT_FILENAME);
 
 		boolean thereIsTrackName = sanitizedTrackName != null && sanitizedTrackName.length() >= 1;
-
 		switch(desiredOutputFormat){
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME:
 				if(thereIsTrackName)
 					result += sanitizedTrackName;
 				else
-					result += formattedTrackStartDate;
-				if(!(exportLabelName.equals("")))
-					result += "_"+ exportLabelName; // fallback case
+					result += formattedTrackStartDate; // fallback case
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME_DATE:
 				if(thereIsTrackName)
@@ -76,8 +73,6 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 					}
 				else
 					result += formattedTrackStartDate;
-				if(!(exportLabelName.equals("")))
-					result += "_"+ exportLabelName;
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE_NAME:
 				if(thereIsTrackName){
@@ -89,15 +84,13 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 				}else{
 					result += formattedTrackStartDate;
 				}
-				if(!(exportLabelName.equals("")))
-					result += "_"+ exportLabelName;
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE:
 				result += formattedTrackStartDate;
-				if(!(exportLabelName.equals("")))
-					result += "_"+ exportLabelName;
 				break;
 		}
+		if(!(exportLabelName.equals("")))
+			result += "_"+ exportLabelName;
 		return result;
 	}
 

--- a/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
@@ -2,8 +2,10 @@ package net.osmtracker.gpx;
 
 import android.content.Context;
 import android.database.Cursor;
+import android.preference.PreferenceManager;
 import android.util.Log;
 
+import net.osmtracker.OSMTracker;
 import net.osmtracker.db.DataHelper;
 import net.osmtracker.exception.ExportTrackException;
 
@@ -26,7 +28,12 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 	public ExportToTempFileTask(Context context, long trackId) {
 		super(context, trackId);
 		try {
-			tmpFile = new File(context.getCacheDir(), new DataHelper(context).getTrackById(trackId).getName()+"_OSMTracker.gpx");
+			String exportLabelName = PreferenceManager.getDefaultSharedPreferences(context).getString(
+					OSMTracker.Preferences.KEY_EXPORT_LABEL,	OSMTracker.Preferences.VAL_EXPORT_LABEL);
+			String trackName = new DataHelper(context).getTrackById(trackId).getName();
+
+			// Create temporary file
+			tmpFile = new File(context.getCacheDir(), trackName + exportLabelName+".gpx");
 			Log.d(TAG, "Temporary file: " + tmpFile.getAbsolutePath());
 
 		} catch (Exception ioe) {

--- a/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
@@ -1,12 +1,17 @@
 package net.osmtracker.gpx;
 
+import android.content.ContentResolver;
+import android.content.ContentUris;
 import android.content.Context;
 import android.database.Cursor;
 import android.preference.PreferenceManager;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import net.osmtracker.OSMTracker;
 import net.osmtracker.db.DataHelper;
+import net.osmtracker.db.TrackContentProvider;
 import net.osmtracker.exception.ExportTrackException;
 
 import java.io.File;
@@ -31,15 +36,69 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 			String exportLabelName = PreferenceManager.getDefaultSharedPreferences(context).getString(
 					OSMTracker.Preferences.KEY_EXPORT_LABEL,	OSMTracker.Preferences.VAL_EXPORT_LABEL);
 			String trackName = new DataHelper(context).getTrackById(trackId).getName();
+			long date = new DataHelper(context).getTrackById(trackId).getStartDate();
+
+			String formattedTrackStartDate = DataHelper.FILENAME_FORMATTER.format(new Date(date));
 
 			// Create temporary file
-			tmpFile = new File(context.getCacheDir(), trackName + exportLabelName+".gpx");
-			Log.d(TAG, "Temporary file: " + tmpFile.getAbsolutePath());
-
+			String namefinal = createFile(trackName, formattedTrackStartDate, exportLabelName);
+			tmpFile = new File(context.getCacheDir(),namefinal+".gpx");
+			Log.d(TAG, "Temporary file: "+ tmpFile.getAbsolutePath());
 		} catch (Exception ioe) {
 			Log.e(TAG, "Could not create temporary file", ioe);
 			throw new IllegalStateException("Could not create temporary file", ioe);
 		}
+	}
+	//create temporary file
+	private String createFile(String sanitizedTrackName, String formattedTrackStartDate, String exportLabelName) throws IOException{
+		String result = "";
+		String desiredOutputFormat = PreferenceManager.getDefaultSharedPreferences(context).getString(
+				OSMTracker.Preferences.KEY_OUTPUT_FILENAME,
+				OSMTracker.Preferences.VAL_OUTPUT_FILENAME);
+
+		boolean thereIsTrackName = sanitizedTrackName != null && sanitizedTrackName.length() >= 1;
+
+		switch(desiredOutputFormat){
+			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME:
+				if(thereIsTrackName)
+					result += sanitizedTrackName;
+				else
+					result += formattedTrackStartDate;
+				if(!(exportLabelName.equals("")))
+					result += "_"+ exportLabelName; // fallback case
+				break;
+			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME_DATE:
+				if(thereIsTrackName)
+					if(sanitizedTrackName.equals(formattedTrackStartDate)) {
+						result += sanitizedTrackName;
+					}else{
+						result += sanitizedTrackName + "_"  + formattedTrackStartDate; // name is not equal
+					}
+				else
+					result += formattedTrackStartDate;
+				if(!(exportLabelName.equals("")))
+					result += "_"+ exportLabelName;
+				break;
+			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE_NAME:
+				if(thereIsTrackName){
+					if(sanitizedTrackName.equals(formattedTrackStartDate)){
+						result += formattedTrackStartDate;
+					}else{
+						result += formattedTrackStartDate  + "_" + sanitizedTrackName;
+					}
+				}else{
+					result += formattedTrackStartDate;
+				}
+				if(!(exportLabelName.equals("")))
+					result += "_"+ exportLabelName;
+				break;
+			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE:
+				result += formattedTrackStartDate;
+				if(!(exportLabelName.equals("")))
+					result += "_"+ exportLabelName;
+				break;
+		}
+		return result;
 	}
 
 	@Override

--- a/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.util.Log;
 
+import net.osmtracker.db.DataHelper;
 import net.osmtracker.exception.ExportTrackException;
 
 import java.io.File;
@@ -25,9 +26,10 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 	public ExportToTempFileTask(Context context, long trackId) {
 		super(context, trackId);
 		try {
-			tmpFile = File.createTempFile("osm-upload", ".gpx", context.getCacheDir());
+			tmpFile = new File(context.getCacheDir(), new DataHelper(context).getTrackById(trackId).getName()+"_OSMTracker.gpx");
 			Log.d(TAG, "Temporary file: " + tmpFile.getAbsolutePath());
-		} catch (IOException ioe) {
+
+		} catch (Exception ioe) {
 			Log.e(TAG, "Could not create temporary file", ioe);
 			throw new IllegalStateException("Could not create temporary file", ioe);
 		}

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -575,33 +575,41 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 		switch(desiredOutputFormat){
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME:
 				if(thereIsTrackName)
-					result += sanitizedTrackName+ "_"+ exportLabelName;
+					result += sanitizedTrackName;
 				else
-					result += formattedTrackStartDate + "_"+ exportLabelName; // fallback case
+					result += formattedTrackStartDate;
+				if(!(exportLabelName.equals("")))
+					result += "_"+ exportLabelName; // fallback case
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME_DATE:
 				if(thereIsTrackName)
 					if(sanitizedTrackName.equals(formattedTrackStartDate)) {
-						result += sanitizedTrackName + "_"  + exportLabelName;
+						result += sanitizedTrackName;
 					}else{
-						result += sanitizedTrackName + "_"  + formattedTrackStartDate + "_"+ exportLabelName; // name is not equal
+						result += sanitizedTrackName + "_"  + formattedTrackStartDate; // name is not equal
 					}
 				else
-					result += formattedTrackStartDate + "_"+ exportLabelName;
+					result += formattedTrackStartDate;
+				if(!(exportLabelName.equals("")))
+					result += "_"+ exportLabelName;
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE_NAME:
 				if(thereIsTrackName){
 					if(sanitizedTrackName.equals(formattedTrackStartDate)){
-						result += formattedTrackStartDate + "_" + exportLabelName;
+						result += formattedTrackStartDate;
 					}else{
-						result += formattedTrackStartDate  + "_" + sanitizedTrackName + "_" + exportLabelName;
+						result += formattedTrackStartDate  + "_" + sanitizedTrackName;
 					}
 				}else{
-					result += formattedTrackStartDate + "_" + exportLabelName;
+					result += formattedTrackStartDate;
 				}
+				if(!(exportLabelName.equals("")))
+					result += "_"+ exportLabelName;
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE:
-				result += formattedTrackStartDate + "_"+exportLabelName;
+				result += formattedTrackStartDate;
+				if(!(exportLabelName.equals("")))
+					result += "_"+ exportLabelName;
 				break;
 		}
 		return result;

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -1,6 +1,5 @@
 package net.osmtracker.gpx;
 
-import android.Manifest;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.ContentResolver;
@@ -8,13 +7,10 @@ import android.content.ContentUris;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
-import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.media.MediaScannerConnection;
 import android.os.AsyncTask;
-import android.os.Environment;
 import android.preference.PreferenceManager;
-import androidx.core.content.ContextCompat;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -579,22 +575,33 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 		switch(desiredOutputFormat){
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME:
 				if(thereIsTrackName)
-					result += sanitizedTrackName+ "-"+ exportLabelName;
+					result += sanitizedTrackName+ "_"+ exportLabelName;
 				else
-					result += formattedTrackStartDate + "-"+ exportLabelName; // fallback case
+					result += formattedTrackStartDate + "_"+ exportLabelName; // fallback case
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME_DATE:
 				if(thereIsTrackName)
 					if(sanitizedTrackName.equals(formattedTrackStartDate)) {
-						result += sanitizedTrackName + "-"  + exportLabelName;
+						result += sanitizedTrackName + "_"  + exportLabelName;
 					}else{
-						result += sanitizedTrackName + "-"  + formattedTrackStartDate + "-"+ exportLabelName; // name is not equal
+						result += sanitizedTrackName + "_"  + formattedTrackStartDate + "_"+ exportLabelName; // name is not equal
 					}
 				else
-					result += formattedTrackStartDate + "-"+ exportLabelName;
+					result += formattedTrackStartDate + "_"+ exportLabelName;
+				break;
+			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE_NAME:
+				if(thereIsTrackName){
+					if(sanitizedTrackName.equals(formattedTrackStartDate)){
+						result += formattedTrackStartDate + "_" + exportLabelName;
+					}else{
+						result += formattedTrackStartDate  + "_" + sanitizedTrackName + "_" + exportLabelName;
+					}
+				}else{
+					result += formattedTrackStartDate + "_" + exportLabelName;
+				}
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE:
-				result += formattedTrackStartDate + "-"+exportLabelName;
+				result += formattedTrackStartDate + "_"+exportLabelName;
 				break;
 		}
 		return result;

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -579,22 +579,22 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 		switch(desiredOutputFormat){
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME:
 				if(thereIsTrackName)
-					result += sanitizedTrackName+ exportLabelName;
+					result += sanitizedTrackName+ "-"+ exportLabelName;
 				else
-					result += formattedTrackStartDate + exportLabelName; // fallback case
+					result += formattedTrackStartDate + "-"+ exportLabelName; // fallback case
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME_DATE:
 				if(thereIsTrackName)
 					if(sanitizedTrackName.equals(formattedTrackStartDate)) {
-						result += sanitizedTrackName + "_"  + exportLabelName;
+						result += sanitizedTrackName + "-"  + exportLabelName;
 					}else{
-						result += sanitizedTrackName + "_"  + formattedTrackStartDate + exportLabelName; // name is not equal
+						result += sanitizedTrackName + "-"  + formattedTrackStartDate + "-"+ exportLabelName; // name is not equal
 					}
 				else
-					result += formattedTrackStartDate + exportLabelName;
+					result += formattedTrackStartDate + "-"+ exportLabelName;
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE:
-				result += formattedTrackStartDate + exportLabelName;
+				result += formattedTrackStartDate + "-"+exportLabelName;
 				break;
 		}
 		return result;

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -571,6 +571,9 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 		String result = "";
 		String exportLabelName = PreferenceManager.getDefaultSharedPreferences(context).getString(
 				OSMTracker.Preferences.KEY_EXPORT_LABEL,	OSMTracker.Preferences.VAL_EXPORT_LABEL);
+		if(exportLabelName == null){
+			exportLabelName = OSMTracker.Preferences.VAL_EXPORT_LABEL;
+		}
 		boolean thereIsTrackName = sanitizedTrackName != null && sanitizedTrackName.length() >= 1;
 
 		switch(desiredOutputFormat){

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -569,23 +569,29 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 
 	public String formatGpxFilename(String desiredOutputFormat, String sanitizedTrackName, String formattedTrackStartDate){
 		String result = "";
+		String exportLabelName = PreferenceManager.getDefaultSharedPreferences(context).getString(
+				OSMTracker.Preferences.KEY_EXPORT_LABEL,	OSMTracker.Preferences.VAL_EXPORT_LABEL);
 		boolean thereIsTrackName = sanitizedTrackName != null && sanitizedTrackName.length() >= 1;
 
 		switch(desiredOutputFormat){
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME:
 				if(thereIsTrackName)
-					result += sanitizedTrackName;
+					result += sanitizedTrackName+ exportLabelName;
 				else
-					result += formattedTrackStartDate; // fallback case
+					result += formattedTrackStartDate + exportLabelName; // fallback case
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME_DATE:
 				if(thereIsTrackName)
-					result += sanitizedTrackName + "_" + formattedTrackStartDate;
+					if(sanitizedTrackName.equals(formattedTrackStartDate)) {
+						result += sanitizedTrackName + "_"  + exportLabelName;
+					}else{
+						result += sanitizedTrackName + "_"  + formattedTrackStartDate + exportLabelName; // name is not equal
+					}
 				else
-					result += formattedTrackStartDate;
+					result += formattedTrackStartDate + exportLabelName;
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE:
-				result += formattedTrackStartDate;
+				result += formattedTrackStartDate + exportLabelName;
 				break;
 		}
 		return result;

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -566,9 +566,9 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 	public String formatGpxFilename(String desiredOutputFormat, String sanitizedTrackName, String formattedTrackStartDate){
 		String result = "";
 		String exportLabelName = PreferenceManager.getDefaultSharedPreferences(context).getString(
-				OSMTracker.Preferences.KEY_EXPORT_LABEL,	OSMTracker.Preferences.VAL_EXPORT_LABEL);
+				OSMTracker.Preferences.KEY_OUTPUT_FILENAME_LABEL,	OSMTracker.Preferences.VAL_OUTPUT_FILENAME_LABEL);
 		if(exportLabelName == null){
-			exportLabelName = OSMTracker.Preferences.VAL_EXPORT_LABEL;
+			exportLabelName = OSMTracker.Preferences.VAL_OUTPUT_FILENAME_LABEL;
 		}
 		boolean thereIsTrackName = sanitizedTrackName != null && sanitizedTrackName.length() >= 1;
 
@@ -578,8 +578,6 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 					result += sanitizedTrackName;
 				else
 					result += formattedTrackStartDate;
-				if(!(exportLabelName.equals("")))
-					result += "_"+ exportLabelName; // fallback case
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_NAME_DATE:
 				if(thereIsTrackName)
@@ -590,8 +588,6 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 					}
 				else
 					result += formattedTrackStartDate;
-				if(!(exportLabelName.equals("")))
-					result += "_"+ exportLabelName;
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE_NAME:
 				if(thereIsTrackName){
@@ -603,14 +599,13 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 				}else{
 					result += formattedTrackStartDate;
 				}
-				if(!(exportLabelName.equals("")))
-					result += "_"+ exportLabelName;
 				break;
 			case OSMTracker.Preferences.VAL_OUTPUT_FILENAME_DATE:
 				result += formattedTrackStartDate;
-				if(!(exportLabelName.equals("")))
-					result += "_"+ exportLabelName;
 				break;
+		}
+		if(!(exportLabelName.equals(""))) {
+			result += "_" + exportLabelName;
 		}
 		return result;
 	}

--- a/app/src/main/res/values/strings-preferences.xml
+++ b/app/src/main/res/values/strings-preferences.xml
@@ -74,6 +74,7 @@
 
 	<string name="prefs_output">GPX settings</string>
 	<string name="prefs_storage_dir">Storage folder in documents</string>
+	<string name="prefs_export_label">Export label for sharing files</string>
 	<string name="prefs_storage_dir_hint">Effective for the next track (not the current one)</string>
 	<string name="prefs_output_one_dir_per_track">One directory per track</string>
 	<string name="prefs_output_one_dir_per_track_summary">Save each track and associated files to its own directory</string>

--- a/app/src/main/res/values/strings-preferences.xml
+++ b/app/src/main/res/values/strings-preferences.xml
@@ -84,7 +84,7 @@
 	<string-array name="prefs_output_filename_keys">
 		<item>Track name</item>
 		<item>Name, start date and time</item>
-		<item>start date and time, name</item>
+		<item>Start date and time, name</item>
 		<item>Start date and time</item>
 
 	</string-array>

--- a/app/src/main/res/values/strings-preferences.xml
+++ b/app/src/main/res/values/strings-preferences.xml
@@ -74,7 +74,8 @@
 
 	<string name="prefs_output">GPX settings</string>
 	<string name="prefs_storage_dir">Storage folder in documents</string>
-	<string name="prefs_export_label">Export label for sharing files</string>
+	<string name="prefs_export_label">Filename label</string>
+	<string name="prefs_export_label_summary">This label will be appended at the end of filename</string>
 	<string name="prefs_storage_dir_hint">Effective for the next track (not the current one)</string>
 	<string name="prefs_output_one_dir_per_track">One directory per track</string>
 	<string name="prefs_output_one_dir_per_track_summary">Save each track and associated files to its own directory</string>
@@ -83,7 +84,9 @@
 	<string-array name="prefs_output_filename_keys">
 		<item>Track name</item>
 		<item>Name, start date and time</item>
+		<item>start date and time, name</item>
 		<item>Start date and time</item>
+
 	</string-array>
 	
 	<string name="prefs_output_accuracy">Accuracy in GPX file</string>

--- a/app/src/main/res/values/values-preferences.xml
+++ b/app/src/main/res/values/values-preferences.xml
@@ -33,6 +33,7 @@
 	<string-array name="prefs_output_filename_values">
 		<item>name</item>
 		<item>name_date</item>
+		<item>date_name</item>
 		<item>date</item>
 	</string-array>
 	

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -57,8 +57,8 @@
 			android:title="@string/prefs_output_one_dir_per_track"
 			android:summary="@string/prefs_output_one_dir_per_track_summary"
 			android:defaultValue="true" />
-		<EditTextPreference android:key="gpx.export.label"
-			android:defaultValue="_OSMTracker" android:title="@string/prefs_export_label"/>
+		<EditTextPreference android:key="gpx.export.label" android:defaultValue="OSMTracker" android:summary="@string/prefs_export_label_summary"
+			android:title="@string/prefs_export_label"/>
 		<ListPreference android:key="gpx.filename" android:defaultValue="name_date" android:summary="@string/prefs_output_filename_summary"
 			android:title="@string/prefs_output_filename" android:entryValues="@array/prefs_output_filename_values"
 			android:entries="@array/prefs_output_filename_keys" />

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -57,6 +57,8 @@
 			android:title="@string/prefs_output_one_dir_per_track"
 			android:summary="@string/prefs_output_one_dir_per_track_summary"
 			android:defaultValue="true" />
+		<EditTextPreference android:key="gpx.export.label"
+			android:defaultValue="_OSMTracker" android:title="@string/prefs_export_label"/>
 		<ListPreference android:key="gpx.filename" android:defaultValue="name_date" android:summary="@string/prefs_output_filename_summary"
 			android:title="@string/prefs_output_filename" android:entryValues="@array/prefs_output_filename_values"
 			android:entries="@array/prefs_output_filename_keys" />

--- a/app/src/test/java/net/osmtracker/gpx/ExportToStorageTaskTest.java
+++ b/app/src/test/java/net/osmtracker/gpx/ExportToStorageTaskTest.java
@@ -83,7 +83,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = "MyTrack_"+Preferences.VAL_EXPORT_LABEL+".gpx";
+        String expectedFilename = "MyTrack_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -94,7 +94,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME_DATE;
 
-        String expectedFilename = "MyTrack_2000-01-02_03-04-05_"+Preferences.VAL_EXPORT_LABEL+".gpx";
+        String expectedFilename = "MyTrack_2000-01-02_03-04-05_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -105,7 +105,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_DATE_NAME;
 
-        String expectedFilename = "2000-01-02_03-04-05_MyTrack_"+Preferences.VAL_EXPORT_LABEL+".gpx";
+        String expectedFilename = "2000-01-02_03-04-05_MyTrack_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -116,7 +116,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_DATE;
 
-        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_EXPORT_LABEL+".gpx";
+        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -127,7 +127,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = ";M_y_T_r_a_c_k;_"+Preferences.VAL_EXPORT_LABEL+".gpx";
+        String expectedFilename = ";M_y_T_r_a_c_k;_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -138,7 +138,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_EXPORT_LABEL+".gpx"; // Must fallback to use the start date
+        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx"; // Must fallback to use the start date
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -149,7 +149,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME_DATE;
 
-        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_EXPORT_LABEL+".gpx"; // Must fallback to use the start date
+        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx"; // Must fallback to use the start date
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }

--- a/app/src/test/java/net/osmtracker/gpx/ExportToStorageTaskTest.java
+++ b/app/src/test/java/net/osmtracker/gpx/ExportToStorageTaskTest.java
@@ -83,7 +83,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = "MyTrack.gpx";
+        String expectedFilename = "MyTrack"+Preferences.VAL_EXPORT_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -94,7 +94,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME_DATE;
 
-        String expectedFilename = "MyTrack_2000-01-02_03-04-05.gpx";
+        String expectedFilename = "MyTrack_2000-01-02_03-04-05"+Preferences.VAL_EXPORT_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -105,7 +105,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_DATE;
 
-        String expectedFilename = "2000-01-02_03-04-05.gpx";
+        String expectedFilename = "2000-01-02_03-04-05"+Preferences.VAL_EXPORT_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -116,7 +116,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = ";M_y_T_r_a_c_k;.gpx";
+        String expectedFilename = ";M_y_T_r_a_c_k;"+Preferences.VAL_EXPORT_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -127,7 +127,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = "2000-01-02_03-04-05.gpx"; // Must fallback to use the start date
+        String expectedFilename = "2000-01-02_03-04-05"+Preferences.VAL_EXPORT_LABEL+".gpx"; // Must fallback to use the start date
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -138,7 +138,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME_DATE;
 
-        String expectedFilename = "2000-01-02_03-04-05.gpx"; // Must fallback to use the start date
+        String expectedFilename = "2000-01-02_03-04-05"+Preferences.VAL_EXPORT_LABEL+".gpx"; // Must fallback to use the start date
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }

--- a/app/src/test/java/net/osmtracker/gpx/ExportToStorageTaskTest.java
+++ b/app/src/test/java/net/osmtracker/gpx/ExportToStorageTaskTest.java
@@ -83,7 +83,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = "MyTrack"+Preferences.VAL_EXPORT_LABEL+".gpx";
+        String expectedFilename = "MyTrack_"+Preferences.VAL_EXPORT_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -94,7 +94,18 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME_DATE;
 
-        String expectedFilename = "MyTrack_2000-01-02_03-04-05"+Preferences.VAL_EXPORT_LABEL+".gpx";
+        String expectedFilename = "MyTrack_2000-01-02_03-04-05_"+Preferences.VAL_EXPORT_LABEL+".gpx";
+
+        doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
+    }
+
+    @Test
+    public void testBuildGPXFilenameUsingStartDateAndTrackName() {
+        String trackNameInDatabase = "MyTrack";
+        Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
+        String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_DATE_NAME;
+
+        String expectedFilename = "2000-01-02_03-04-05_MyTrack_"+Preferences.VAL_EXPORT_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -105,7 +116,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_DATE;
 
-        String expectedFilename = "2000-01-02_03-04-05"+Preferences.VAL_EXPORT_LABEL+".gpx";
+        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_EXPORT_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -116,7 +127,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = ";M_y_T_r_a_c_k;"+Preferences.VAL_EXPORT_LABEL+".gpx";
+        String expectedFilename = ";M_y_T_r_a_c_k;_"+Preferences.VAL_EXPORT_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -127,7 +138,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = "2000-01-02_03-04-05"+Preferences.VAL_EXPORT_LABEL+".gpx"; // Must fallback to use the start date
+        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_EXPORT_LABEL+".gpx"; // Must fallback to use the start date
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -138,7 +149,7 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME_DATE;
 
-        String expectedFilename = "2000-01-02_03-04-05"+Preferences.VAL_EXPORT_LABEL+".gpx"; // Must fallback to use the start date
+        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_EXPORT_LABEL+".gpx"; // Must fallback to use the start date
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }


### PR DESCRIPTION
* This PR is an extended feature of issue #333 according to #470.

It allows the user to add a custom suffix label to the name of GPX files when sharing.

### Instructions for Use
In `Settings > GPX Settings`, the option **"Export label for sharing files"** allows the user to customize the suffix of a track for export as a `.gpx` file. The exported file will follow the format:  
`YYYY-MM-DD_hh-mm-ss_EXPORT_LABEL`, where `_EXPORT_LABEL` defaults to `_OSMTracker`.
