### PR TITLE
Added background color for intro activity

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/Intro.kt
+++ b/app/src/main/java/net/osmtracker/activity/Intro.kt
@@ -18,6 +18,7 @@ class Intro : AppIntro() {
         addSlide(AppIntroFragment.createInstance(
                 title = getString(R.string.app_intro_slide1_title),
                 imageDrawable = R.drawable.icon_100x100,
+                backgroundColorRes = R.color.appintro_background_color,
                 description = getString(R.string.app_intro_slide1_description)
         ))
 
@@ -25,6 +26,7 @@ class Intro : AppIntro() {
         addSlide(AppIntroFragment.createInstance(
                 title = getString(R.string.app_intro_slide2_title),
                 imageDrawable = R.drawable.icon_100x100,
+                backgroundColorRes = R.color.appintro_background_color,
                 description = getString(R.string.app_intro_slide2_description)
         ))
     }


### PR DESCRIPTION
Background color added for intro activity. Now we have a consistent color for cellphones with the dark or light mode on.

See the comment https://github.com/labexp/osmtracker-android/commit/431b7f3b7b67b7f6029989078c92f9853ad4ad30#r150085284 for more information

> ... with the update to `com.github.AppIntro:AppIntro` we have to set the background to match the light / dark theme. At the moment our intro has a light background when the phone has dark mode off.