### PR TITLE
Text Size and Layout Adjustments for Large Text Setting Compatibility

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/AvailableLayouts.java
+++ b/app/src/main/java/net/osmtracker/activity/AvailableLayouts.java
@@ -157,7 +157,7 @@ public class AvailableLayouts extends Activity {
             LinearLayout.LayoutParams layoutParams = new LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
             layoutParams.setMargins(50, 10, 50, 10);
             layoutButton.setLayoutParams(layoutParams);
-            layoutButton.setPadding(10,20,10,20);
+            layoutButton.setPadding(40, 30, 40, 30);
             layoutButton.setOnClickListener(listener);
             rootLayout.addView(layoutButton,AT_START);
         }

--- a/app/src/main/res/layout/tracklist_item.xml
+++ b/app/src/main/res/layout/tracklist_item.xml
@@ -41,8 +41,11 @@
 			style="@android:style/TextAppearance.Large"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
-			android:autoSizeTextType="uniform"   
-			android:maxLines="1"       
+			android:autoSizeTextType="uniform"
+			android:autoSizeMinTextSize="12sp"
+    		android:autoSizeMaxTextSize="14sp" 
+			android:autoSizeStepGranularity="2sp"
+			android:maxLines="1"    
 			android:text="{start_date}" />
 
 		<LinearLayout

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -62,6 +62,7 @@
   <string name="trackdetail_export_notyet">(Jeszcze nie wyeksportowano)</string>
   <string name="trackdetail_osm_upload_notyet">(Jeszcze nie wysłano)</string>
   <string name="trackdetail_export_display">Wyświetl</string>
+  <string name="trackdetail_name">Nazwa</string>
   <string name="trackdetail_description">Opis</string>
   <string name="trackdetail_tags">Tagi (oddzielone przecinkami)</string>
   <string name="trackdetail_description_mandatory">Musisz wpisać opis.</string>
@@ -107,6 +108,14 @@ głosową</string>
   <string name="error_externalstorage_not_writable_hint">Proszę sprawdzić wew. pamięć czy jest prawidłowo zamontowana.</string>
   <string name="error_voicerec_failed">Nagrywanie głosu nie powiodło się</string>
   <string name="error_userlayout_parsing">Błąd podczas przetwarzania pliku XML. Proszę powrócić do domyślnego układu.</string>
+  <!--messages-->
+  <string name="permission_required">Wymagane pozwolenie</string>
+  <string name="storage_permission_for_export_GPX">Aby wyeksportować ślad GPX, musimy zapisać go w pamięci.</string>
+  <string name="storage_permission_for_display_track">Aby poprawnie wyświetlić ścieżkę potrzebujemy dostępu do magazynu.</string>
+  <string name="storage_permission_for_share_track">Aby prawidłowo udostępnić ścieżkę potrzebujemy dostępu do magazynu.</string>
+  <string name="storage_permission_for_upload_to_OSM">Aby przesłać ścieżkę do OSM, potrzebujemy dostępu do magazynu.</string>
+  <string name="acccept">Zgoda</string>
+  <string name="gps_perms_required">Nie można kontynuować bez przyzwolenia na GPS</string>
   <!--GPX-->
   <string name="gpx_track_name">Ślad zapisany przez OSMTracker - Android™</string>
   <string name="gpx_hdop_approximation_cmt">UWAGA: wartości HDOP nie są pobierane z urządzenia GPS. Są to dane orientacyjne podane w metrach.</string>


### PR DESCRIPTION
This PR addresses the issue mentioned in #347, where the problem was related to the size of the text when the largest text size setting is activated on the phone. Thanks to @miltonials, we confirmed that the problem mentioned in the PR was already solved with a scroll. However, during testing, we identified additional issues.

**First problem**
In the track manager the text for date, name, trackpoints and waypoints was to big for his container.

**Example of the problem**
![image](https://github.com/user-attachments/assets/02fa4c16-8614-4742-a27d-97feb1f70f14)

**How i solved it**
- I added two possible text sizes
    - For normal text size settings, the appearance remains unchanged.
    - For the largest text size setting, the text increases, but not excessively.
- I adjusted the trackpoints and waypoints labels to display vertically, improving the app's overall look and resolving the text overflow problem.

**How it looks now**
![image](https://github.com/user-attachments/assets/134f9850-5adf-45b1-99b4-9c6edd105082)

**Second problem**
In the "Add Button Presets" section, when the available presets were displayed, the text didn’t fit within the button component.

**Example of the problem**
![image](https://github.com/user-attachments/assets/cadcd3a8-9c31-483b-8a4a-c1a91e14d6b0)

**How i solved it**
I increased the padding and margin of the buttons to provide more space.
I adjusted the text size to fit appropriately in all cases.

**How it looks now**
![image](https://github.com/user-attachments/assets/eef6cdeb-3520-4b5c-80da-99279096c103)