### PR TITLE
fix “Uploaded to OpenStreetMap” always reported as “1 Jan 1970 01:00:00” #314

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/TrackDetail.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackDetail.java
@@ -181,7 +181,7 @@ public class TrackDetail extends TrackDetailEditor implements AdapterView.OnItem
 		if (cursor.isNull(cursor.getColumnIndex(TrackContentProvider.Schema.COL_OSM_UPLOAD_DATE))) {
 			map.put(ITEM_VALUE, getResources().getString(R.string.trackdetail_osm_upload_notyet));
 		} else {
-			map.put(ITEM_VALUE, DateFormat.getDateTimeInstance().format(new Date(cursor.getLong(cursor.getColumnIndex(TrackContentProvider.Schema.COL_EXPORT_DATE)))));
+			map.put(ITEM_VALUE, DateFormat.getDateTimeInstance().format(new Date(cursor.getLong(cursor.getColumnIndex(TrackContentProvider.Schema.COL_OSM_UPLOAD_DATE)))));
 		}
 		data.add(map);
 		


### PR DESCRIPTION
This pull request includes a change to the `TrackDetail` activity in the Android application to fix a bug related to the display of the OSM upload date.

Bug fix:

* [`app/src/main/java/net/osmtracker/activity/TrackDetail.java`](diffhunk://#diff-92a4f5de89e4668a325d4625e957ebc21fa22ccd8d7a3d56396951b82495eeabL184-R184): Corrected the column used to fetch the OSM upload date in the `onResume` method to display the correct date.

issue resolved:
* #314 