### PR TITLE
Fix visibility of horizontal dividers in TrackManager (Issue #311)

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -115,6 +115,14 @@ public class TrackManager extends AppCompatActivity
 			Intent intro = new Intent(this, Intro.class);
 			startActivity(intro);
 		}
+		RecyclerView recyclerView = findViewById(R.id.recyclerview);
+		recyclerView.setLayoutManager(new LinearLayoutManager(this));
+
+		// Adding a horizontal divider
+		DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(recyclerView.getContext(), DividerItemDecoration.VERTICAL);
+		dividerItemDecoration.setDrawable(ContextCompat.getDrawable(this, R.drawable.divider)); // Using a custom drawable
+
+		recyclerView.addItemDecoration(dividerItemDecoration);
 	}
 
 	@Override

--- a/app/src/main/res/drawable/divider.xml
+++ b/app/src/main/res/drawable/divider.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <size android:height="2dp" />
+    <solid android:color="#fff" />
+</shape>


### PR DESCRIPTION
solution to the issue:

* #311 

a white dividing line has been added so that the division of each trace can be clearly seen.

![image](https://github.com/user-attachments/assets/59f2c42d-1d37-4e0a-b1a3-6842d3460427)
