### PR TITLE
Improved GPX Sharing: Share as ZIP

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -582,7 +582,7 @@ public class TrackManager extends AppCompatActivity
 		new ExportToTempFileTask(context, trackId){
 			@Override
 			protected void executionCompleted(){
-				// Create zip file or an archive in case there are no files associated with the trace
+				// Creates a zip file with the trace and its multimedia files
 				File zipFile = ZipHelper.zipCacheFiles(context, trackId, this.getTmpFile());
 				shareFile(zipFile, context);
 			}

--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -40,6 +40,7 @@ import net.osmtracker.db.TrackContentProvider;
 import net.osmtracker.exception.CreateTrackException;
 import net.osmtracker.gpx.ExportToStorageTask;
 import net.osmtracker.gpx.ExportToTempFileTask;
+import net.osmtracker.gpx.ZipHelper;
 import net.osmtracker.util.FileSystemUtils;
 
 import java.io.File;
@@ -581,7 +582,8 @@ public class TrackManager extends AppCompatActivity
 		new ExportToTempFileTask(context, trackId){
 			@Override
 			protected void executionCompleted(){
-				shareFile(this.getTmpFile(), context);
+				File zipFile = ZipHelper.zipCacheFiles(context, trackId, this.getTmpFile()); // Create zip file or an archive in case there are no files associated with the trace
+				shareFile(zipFile, context);
 			}
 
 			@Override

--- a/app/src/main/java/net/osmtracker/activity/TrackManager.java
+++ b/app/src/main/java/net/osmtracker/activity/TrackManager.java
@@ -582,7 +582,8 @@ public class TrackManager extends AppCompatActivity
 		new ExportToTempFileTask(context, trackId){
 			@Override
 			protected void executionCompleted(){
-				File zipFile = ZipHelper.zipCacheFiles(context, trackId, this.getTmpFile()); // Create zip file or an archive in case there are no files associated with the trace
+				// Create zip file or an archive in case there are no files associated with the trace
+				File zipFile = ZipHelper.zipCacheFiles(context, trackId, this.getTmpFile());
 				shareFile(zipFile, context);
 			}
 

--- a/app/src/main/java/net/osmtracker/db/DataHelper.java
+++ b/app/src/main/java/net/osmtracker/db/DataHelper.java
@@ -49,6 +49,11 @@ public class DataHelper {
 	public static final String EXTENSION_JPG = ".jpg";
 
 	/**
+	 * ZIP file extension
+	 */
+	public static final String EXTENSION_ZIP = ".zip";
+
+	/**
 	 * GPX Files MIME standard for sharing
 	 */
 	public static final String MIME_TYPE_GPX = "application/gpx+xml";

--- a/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportToTempFileTask.java
@@ -36,7 +36,7 @@ public abstract class ExportToTempFileTask extends ExportTrackTask {
 			String exportLabelName = PreferenceManager.getDefaultSharedPreferences(context).getString(
 					OSMTracker.Preferences.KEY_OUTPUT_FILENAME_LABEL,	OSMTracker.Preferences.VAL_OUTPUT_FILENAME_LABEL);
 			String trackName = new DataHelper(context).getTrackById(trackId).getName();
-			long date = new DataHelper(context).getTrackById(trackId).getStartDate();
+			long date = new DataHelper(context).getTrackById(trackId).getTrackDate();
 
 			String formattedTrackStartDate = DataHelper.FILENAME_FORMATTER.format(new Date(date));
 

--- a/app/src/main/java/net/osmtracker/gpx/ZipHelper.java
+++ b/app/src/main/java/net/osmtracker/gpx/ZipHelper.java
@@ -1,0 +1,90 @@
+package net.osmtracker.gpx;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.io.*;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import net.osmtracker.db.DataHelper;
+
+public class ZipHelper {
+
+    private static final String TAG = "ZipHelper";
+
+    /**
+     * Compresses all files associated with a track into a ZIP file.
+     *
+     * @param context   Application context.
+     * @param trackId   Track ID.
+     * @param filegpx   Original GPX file.
+     * @return The created ZIP file or null if an error occurred.
+     */
+    public static File zipCacheFiles(Context context, long trackId, File filegpx) {
+        File directory = DataHelper.getTrackDirectory(trackId,context);
+        if (!directory.exists() || !directory.isDirectory()) {
+            return filegpx;
+        }
+
+        File[] files = directory.listFiles();
+        if (files == null || files.length == 0) {
+            Log.e(TAG, "No hay archivos para comprimir en: " + directory.getAbsolutePath());
+            return null;
+        }
+        String name = filegpx.getName();
+
+        File zipFile = new File(context.getCacheDir(), name.substring(0, name.length() - 3)+"zip");
+
+        try (FileOutputStream fos = new FileOutputStream(zipFile);
+             ZipOutputStream zos = new ZipOutputStream(fos)) {
+
+            for (File file : files) {
+                if (!file.isDirectory()) { // Evita agregar carpetas vacías
+                    // solo se agrega archivos que no sean .zip
+                    if (!file.getName().endsWith(".zip")) {
+                        addFileToZip(file, zos);
+                    }else {
+                        Log.d(TAG, "No se agrega archivo: " + file.getAbsolutePath());
+                    }
+                }
+            }
+            // Agrega el archivo gpx original
+            addFileToZip(filegpx, zos);
+
+            Log.d(TAG, "Archivo ZIP creado: " + zipFile.getAbsolutePath());
+            return zipFile;
+
+        } catch (IOException e) {
+            Log.e(TAG, "Error al crear el archivo ZIP", e);
+            return null;
+        }
+    }
+
+
+    /**
+     * Adds a file to the ZIP archive.
+     *
+     * @param file The file to add.
+     * @param zos  The ZipOutputStream to which the file will be added.
+     */
+    private static void addFileToZip(File file, ZipOutputStream zos) throws IOException {
+        if (!file.exists()) {
+            Log.e(TAG, "Archivo no encontrado: " + file.getAbsolutePath());
+            return;
+        }
+
+        try (FileInputStream fis = new FileInputStream(file)) {
+            ZipEntry zipEntry = new ZipEntry(file.getName());
+            zos.putNextEntry(zipEntry);
+
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = fis.read(buffer)) > 0) {
+                zos.write(buffer, 0, length);
+            }
+
+            zos.closeEntry();
+        }
+    }
+}

--- a/app/src/main/java/net/osmtracker/gpx/ZipHelper.java
+++ b/app/src/main/java/net/osmtracker/gpx/ZipHelper.java
@@ -3,7 +3,10 @@ package net.osmtracker.gpx;
 import android.content.Context;
 import android.util.Log;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -29,7 +32,7 @@ public class ZipHelper {
 
         File[] files = directory.listFiles();
         if (files == null || files.length == 0) {
-            Log.e(TAG, "No hay archivos para comprimir en: " + directory.getAbsolutePath());
+            Log.e(TAG, "There are no files to compress in: " + directory.getAbsolutePath());
             return null;
         }
         String name = filegpx.getName();
@@ -40,23 +43,23 @@ public class ZipHelper {
              ZipOutputStream zos = new ZipOutputStream(fos)) {
 
             for (File file : files) {
-                if (!file.isDirectory()) { // Evita agregar carpetas vacías
-                    // solo se agrega archivos que no sean .zip
+                if (!file.isDirectory()) { // Avoid adding empty folders
+                    // only add files that are not .zip files
                     if (!file.getName().endsWith(".zip")) {
                         addFileToZip(file, zos);
                     }else {
-                        Log.d(TAG, "No se agrega archivo: " + file.getAbsolutePath());
+                        Log.d(TAG, "No file is added: " + file.getAbsolutePath());
                     }
                 }
             }
-            // Agrega el archivo gpx original
+            // Adds the original gpx file
             addFileToZip(filegpx, zos);
 
-            Log.d(TAG, "Archivo ZIP creado: " + zipFile.getAbsolutePath());
+            Log.d(TAG, "ZIP file created: " + zipFile.getAbsolutePath());
             return zipFile;
 
         } catch (IOException e) {
-            Log.e(TAG, "Error al crear el archivo ZIP", e);
+            Log.e(TAG, "Error creating ZIP file", e);
             return null;
         }
     }
@@ -70,7 +73,7 @@ public class ZipHelper {
      */
     private static void addFileToZip(File file, ZipOutputStream zos) throws IOException {
         if (!file.exists()) {
-            Log.e(TAG, "Archivo no encontrado: " + file.getAbsolutePath());
+            Log.e(TAG, "File does not exist: " + file.getAbsolutePath());
             return;
         }
 

--- a/app/src/main/java/net/osmtracker/gpx/ZipHelper.java
+++ b/app/src/main/java/net/osmtracker/gpx/ZipHelper.java
@@ -36,6 +36,13 @@ public class ZipHelper {
         try (FileOutputStream fos = new FileOutputStream(zipFile);
              ZipOutputStream zos = new ZipOutputStream(fos)) {
 
+            // Add gpx file
+            addFileToZip(fileGPX, zos);
+
+            if(!traceFilesDirectory.exists()){
+                return zipFile;
+            }
+
             for (File multimediaFile : Objects.requireNonNull(traceFilesDirectory.listFiles())) {
                 if (!multimediaFile.isDirectory()) { // Avoid adding empty folders
                     // only add files that are not .zip files
@@ -48,9 +55,6 @@ public class ZipHelper {
                     Log.d(TAG, "Folder " + multimediaFile.getAbsolutePath() + " ignored. ");
                 }
             }
-
-            // Adds the original gpx file
-            addFileToZip(fileGPX, zos);
 
             Log.d(TAG, "ZIP file created: " + zipFile.getAbsolutePath());
             return zipFile;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -40,8 +40,8 @@
     <string name="trackmgr_contextmenu_stop">Stop tracking</string>
     <string name="trackmgr_contextmenu_resume">Resume tracking</string>
     <string name="trackmgr_contextmenu_delete">Delete</string>
-    <string name="trackmgr_contextmenu_export">Export as GPX</string>
-    <string name="trackmgr_contextmenu_share">Share GPX</string>
+    <string name="trackmgr_contextmenu_export">Export</string>
+    <string name="trackmgr_contextmenu_share">Share</string>
     <string name="trackmgr_contextmenu_osm_upload">Upload to OpenStreetMap</string>
     <string name="trackmgr_contextmenu_display">Display</string>
     <string name="trackmgr_contextmenu_details">Details</string>


### PR DESCRIPTION
This update enhances the GPX sharing functionality by introducing the ability to share traces as a ZIP file when associated files (e.g., images or other media) are present. If no associated files are detected, the trace is shared as a standard GPX file. This improvement ensures better handling of additional trace data and facilitates seamless sharing of complete trace information.

This feature was implemented in collaboration with [@Kevin-Salazar-itcr](https://github.com/Kevin-Salazar-itcr) and [@FR3DD221](https://github.com/FR3DD221)