### PR TITLE
Upload track as ZIP instead of GPX to reduce file size (#64)

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/OpenStreetMapUpload.java
+++ b/app/src/main/java/net/osmtracker/activity/OpenStreetMapUpload.java
@@ -23,11 +23,15 @@ import net.openid.appauth.ResponseTypeValues;
 import net.openid.appauth.TokenResponse;
 import net.osmtracker.OSMTracker;
 import net.osmtracker.R;
+import net.osmtracker.db.DataHelper;
 import net.osmtracker.db.TrackContentProvider;
 import net.osmtracker.db.model.Track;
 import net.osmtracker.gpx.ExportToTempFileTask;
+import net.osmtracker.gpx.ZipHelper;
 import net.osmtracker.osm.OpenStreetMapConstants;
 import net.osmtracker.osm.UploadToOpenStreetMapTask;
+
+import java.io.File;
 
 /**
  * <p>Uploads a track on OSM using the API and
@@ -205,8 +209,10 @@ public class OpenStreetMapUpload extends TrackDetailEditor {
 		new ExportToTempFileTask(this, trackId) {
 			@Override
 			protected void executionCompleted() {
+				File fileZip = ZipHelper.zipGPXFile(context,trackId, getTmpFile());
+				String filename = getFilename().substring(0, getFilename().length() - 3) + DataHelper.EXTENSION_ZIP;
 				new UploadToOpenStreetMapTask(OpenStreetMapUpload.this, accessToken,
-						trackId, this.getTmpFile(),	this.getFilename(),
+						trackId, fileZip,	filename,
 						etDescription.getText().toString(), etTags.getText().toString(),
 						Track.OSMVisibility.fromPosition(
 								OpenStreetMapUpload.this.spVisibility.getSelectedItemPosition())

--- a/app/src/main/java/net/osmtracker/gpx/ZipHelper.java
+++ b/app/src/main/java/net/osmtracker/gpx/ZipHelper.java
@@ -64,7 +64,32 @@ public class ZipHelper {
             return null;
         }
     }
+    /**
+     * Compresses track into a ZIP file.
+     *
+     * @param context   Application context.
+     * @param trackId   Track ID.
+     * @param fileGPX   GPX file.
+     * @return The created ZIP file or null if an error occurred.
+     */
+    public static File zipGPXFile(Context context, long trackId, File fileGPX) {
 
+        String name = fileGPX.getName();
+        File zipFile = new File(context.getCacheDir(),
+                name.substring(0, name.length() - 3) + DataHelper.EXTENSION_ZIP);
+
+        try (FileOutputStream fos = new FileOutputStream(zipFile);
+             ZipOutputStream zos = new ZipOutputStream(fos)) {
+
+            // Add gpx file
+            addFileToZip(fileGPX, zos);
+        }
+        catch (IOException e) {
+            Log.e(TAG, "Error creating ZIP file", e);
+            return null;
+        }
+        return zipFile;
+    }
 
     /**
      * Adds a file to the ZIP archive.


### PR DESCRIPTION
This PR modifies the track upload process by compressing the GPX file into a ZIP before uploading to the OSM server, addressing issue, 
* #64.

Changes:
* Instead of uploading a raw GPX file, the track is now zipped before upload.
* Ensures compatibility with OSM, which supports ZIP uploads natively.
* Reduces file size, making uploads faster and more efficient.

Benefits:
* Smaller file size → Saves bandwidth and reduces upload time.
* Optimized for mobile users → Less data consumption when not on Wi-Fi.
* Preserves all track data → No loss of information in the compression process.

Dependency:
⚠️ Before merging this PR, PR [#501: Improved GPX Sharing: Share as ZIP](https://github.com/labexp/osmtracker-android/pull/501) must be approved and merged.

Let me know if any adjustments are needed! 🚀