### PR TITLE
fix: Add fitsSystemWindows to handle edge-to-edge behavior in Android 15

### DIFF
--- a/app/src/main/res/layout/trackdetail.xml
+++ b/app/src/main/res/layout/trackdetail.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent" >
+    android:layout_height="fill_parent" 
+    android:fitsSystemWindows="true">
 
     <LinearLayout
         android:id="@+id/trackdetail_buttons"

--- a/app/src/main/res/layout/tracklist_item.xml
+++ b/app/src/main/res/layout/tracklist_item.xml
@@ -1,142 +1,116 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_width="match_parent"
-	android:layout_height="wrap_content"
-	android:baselineAligned="true"
-	android:gravity="start|center_vertical"
-	android:orientation="horizontal"
-	android:paddingLeft="3dp"
-	android:paddingTop="5dp"
-	android:paddingRight="3dp"
-	android:paddingBottom="5dp">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:baselineAligned="false"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:padding="5dp">
 
-	<TextView
-		android:id="@+id/trackmgr_item_id_symbol"
-		style="@android:style/TextAppearance.Medium"
-		android:layout_width="wrap_content"
-		android:layout_height="fill_parent"
-		android:layout_marginEnd="5dp"
-		android:layout_marginRight="5dp"
-		android:gravity="start|center_vertical"
-		android:text="#" />
-
-	<TextView
-		android:id="@+id/trackmgr_item_id"
-		style="@android:style/TextAppearance.Medium"
-		android:layout_width="wrap_content"
-		android:layout_height="fill_parent"
-		android:layout_marginEnd="5dp"
-		android:layout_marginRight="5dp"
-		android:gravity="start|center_vertical"
-		android:text="{id}" />
-
-	<RelativeLayout
-		android:layout_width="0dip"
-		android:layout_height="fill_parent"
-		android:layout_weight="1"
-		android:gravity="start|center_vertical">
-
-		<TextView
-			android:id="@+id/trackmgr_item_nameordate"
-			style="@android:style/TextAppearance.Large"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:autoSizeTextType="uniform"
-			android:autoSizeMinTextSize="12sp"
-    		android:autoSizeMaxTextSize="14sp" 
-			android:autoSizeStepGranularity="2sp"
-			android:maxLines="1"    
-			android:text="{start_date}" />
-
-		<LinearLayout
-        android:id="@+id/waypoints_container"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/trackmgr_item_nameordate"
-        android:orientation="horizontal">
+        android:orientation="vertical"
+        android:layout_marginEnd="8dp">
+        <TextView
+            android:id="@+id/trackmgr_item_id_symbol"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="#"
+            android:textAppearance="?android:attr/textAppearanceMedium"/>
+        <TextView
+            android:id="@+id/trackmgr_item_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="{id}"
+            android:textAppearance="?android:attr/textAppearanceMedium"/>
+    </LinearLayout>
 
-			<TextView
-				android:id="@+id/trackmgr_item_waypoints"
-				style="@android:style/TextAppearance.Small"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:layout_below="@+id/trackmgr_item_nameordate"
-				android:layout_marginStart="8dp"
-				android:layout_marginLeft="8dp"
-				android:layout_marginEnd="3dp"
-				android:layout_marginRight="3dp"
-				android:text="@string/trackmgr_waypoints_count"
-				android:textStyle="bold" />
-
-			<TextView
-				android:id="@+id/trackmgr_item_wps"
-				style="@android:style/TextAppearance.Small"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:layout_below="@id/trackmgr_item_nameordate"
-				android:layout_toEndOf="@id/trackmgr_item_waypoints"
-				android:layout_toRightOf="@id/trackmgr_item_waypoints"
-				android:text="{x}" />
-		</LinearLayout>
-
-		<LinearLayout
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_below="@+id/waypoints_container"
-        android:orientation="horizontal">
+        android:layout_weight="1"
+        android:orientation="vertical">
 
-			<TextView
-				android:id="@+id/trackmgr_item_trackpoints"
-				style="@android:style/TextAppearance.Small"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:layout_below="@id/trackmgr_item_nameordate"
-				android:layout_marginStart="8dp"
-				android:layout_marginLeft="8dp"
-				android:layout_marginEnd="3dp"
-				android:layout_marginRight="3dp"
-				android:layout_toEndOf="@id/trackmgr_item_wps"
-				android:layout_toRightOf="@id/trackmgr_item_wps"
-				android:text="@string/trackmgr_trackpoints_count"
-				android:textStyle="bold" />
+        <TextView
+            android:id="@+id/trackmgr_item_nameordate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:autoSizeTextType="uniform"
+            android:autoSizeMinTextSize="12sp"
+            android:autoSizeMaxTextSize="20sp"
+            android:autoSizeStepGranularity="2sp"
+            android:maxLines="1"
+            android:text="{start_date}"
+            android:textAppearance="?android:attr/textAppearanceLarge"/>
 
-			<TextView
-				android:id="@+id/trackmgr_item_tps"
-				style="@android:style/TextAppearance.Small"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:layout_below="@id/trackmgr_item_nameordate"
-				android:layout_toEndOf="@id/trackmgr_item_trackpoints"
-				android:layout_toRightOf="@id/trackmgr_item_trackpoints"
-				android:text="{y}" />
+        <LinearLayout
+            android:id="@+id/waypoints_container"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
 
-		</LinearLayout>
+            <TextView
+                android:id="@+id/trackmgr_item_waypoints"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/trackmgr_waypoints_count"
+                android:textStyle="bold"
+                android:textAppearance="?android:attr/textAppearanceSmall"/>
 
-	</RelativeLayout>
+            <TextView
+                android:id="@+id/trackmgr_item_wps"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:text="{x}"
+                android:textAppearance="?android:attr/textAppearanceSmall"/>
+        </LinearLayout>
 
-	<ImageView
-		android:id="@+id/trackmgr_item_statusicon"
-		android:layout_width="wrap_content"
-		android:layout_height="fill_parent"
-		android:layout_gravity="center_horizontal|center_vertical"
-		android:layout_marginLeft="3dp"
-		android:layout_marginRight="3dp"
-		android:contentDescription="@string/acc.track_status"
-		android:paddingLeft="3dp"
-		android:paddingRight="3dp"
-		android:src="@android:drawable/presence_online" />
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
 
-	<ImageView
-		android:id="@+id/trackmgr_item_upload_statusicon"
-		android:layout_width="wrap_content"
-		android:layout_height="fill_parent"
-		android:layout_gravity="center_horizontal|center_vertical"
-		android:layout_marginLeft="3dp"
-		android:layout_marginRight="3dp"
-		android:contentDescription="@string/acc.upload_status"
-		android:paddingLeft="3dp"
-		android:paddingRight="3dp"
-		android:src="@android:drawable/stat_sys_upload_done" />
+            <TextView
+                android:id="@+id/trackmgr_item_trackpoints"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/trackmgr_trackpoints_count"
+                android:textStyle="bold"
+                android:textAppearance="?android:attr/textAppearanceSmall"/>
 
+            <TextView
+                android:id="@+id/trackmgr_item_tps"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:text="{y}"
+                android:textAppearance="?android:attr/textAppearanceSmall"/>
+        </LinearLayout>
+    </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:gravity="center">
+
+        <ImageView
+            android:id="@+id/trackmgr_item_statusicon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="4dp"
+            android:contentDescription="@string/acc.track_status"
+            android:src="@android:drawable/presence_online"/>
+
+        <ImageView
+            android:id="@+id/trackmgr_item_upload_statusicon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="4dp"
+            android:contentDescription="@string/acc.upload_status"
+            android:src="@android:drawable/stat_sys_upload_done"/>
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/tracklist_item.xml
+++ b/app/src/main/res/layout/tracklist_item.xml
@@ -1,116 +1,155 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout 
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:baselineAligned="false"
-    android:gravity="center_vertical"
-    android:orientation="horizontal"
-    android:padding="5dp">
+    android:minHeight="72dp"
+    android:padding="5dp"
+    android:stateListAnimator="@null"
+    android:background="?android:attr/selectableItemBackground">
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/trackmgr_item_id_symbol"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:layout_marginEnd="8dp">
-        <TextView
-            android:id="@+id/trackmgr_item_id_symbol"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="#"
-            android:textAppearance="?android:attr/textAppearanceMedium"/>
-        <TextView
-            android:id="@+id/trackmgr_item_id"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="{id}"
-            android:textAppearance="?android:attr/textAppearanceMedium"/>
-    </LinearLayout>
+        android:text="#"
+        android:padding="5dp"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:duplicateParentState="false"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/trackmgr_item_id"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="{id}"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:duplicateParentState="false"
+        app:layout_constraintStart_toStartOf="@id/trackmgr_item_id_symbol"
+        app:layout_constraintTop_toBottomOf="@id/trackmgr_item_id_symbol"/>
+
+    <TextView
+        android:id="@+id/trackmgr_item_nameordate"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:orientation="vertical">
+        android:layout_marginStart="8dp"
+        android:layout_marginBottom="4dp"
+        android:autoSizeTextType="uniform"
+        android:autoSizeMinTextSize="12sp"
+        android:autoSizeMaxTextSize="20sp"
+        android:autoSizeStepGranularity="2sp"
+        android:maxLines="1"
+        android:text="{start_date}"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:duplicateParentState="false"
+        app:layout_constraintStart_toEndOf="@id/trackmgr_item_id_symbol"
+        app:layout_constraintEnd_toStartOf="@id/icons_container"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <LinearLayout
+        android:id="@+id/waypoints_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="4dp"
+        android:orientation="horizontal"
+        app:layout_constraintStart_toEndOf="@id/trackmgr_item_id_symbol"
+        app:layout_constraintTop_toBottomOf="@id/trackmgr_item_nameordate">
 
         <TextView
-            android:id="@+id/trackmgr_item_nameordate"
+            android:id="@+id/trackmgr_item_waypoints"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:autoSizeTextType="uniform"
-            android:autoSizeMinTextSize="12sp"
-            android:autoSizeMaxTextSize="20sp"
-            android:autoSizeStepGranularity="2sp"
-            android:maxLines="1"
-            android:text="{start_date}"
-            android:textAppearance="?android:attr/textAppearanceLarge"/>
+            android:text="@string/trackmgr_waypoints_count"
+            android:textStyle="bold"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:duplicateParentState="false"/>
 
-        <LinearLayout
-            android:id="@+id/waypoints_container"
+        <TextView
+            android:id="@+id/trackmgr_item_wps"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/trackmgr_item_waypoints"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/trackmgr_waypoints_count"
-                android:textStyle="bold"
-                android:textAppearance="?android:attr/textAppearanceSmall"/>
-
-            <TextView
-                android:id="@+id/trackmgr_item_wps"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:text="{x}"
-                android:textAppearance="?android:attr/textAppearanceSmall"/>
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:id="@+id/trackmgr_item_trackpoints"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/trackmgr_trackpoints_count"
-                android:textStyle="bold"
-                android:textAppearance="?android:attr/textAppearanceSmall"/>
-
-            <TextView
-                android:id="@+id/trackmgr_item_tps"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="4dp"
-                android:text="{y}"
-                android:textAppearance="?android:attr/textAppearanceSmall"/>
-        </LinearLayout>
+            android:layout_marginStart="4dp"
+            android:text="{x}"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:duplicateParentState="false"/>
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/trackpoints_container"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginEnd="8dp"
+        android:orientation="horizontal"
+        app:layout_constraintStart_toEndOf="@id/trackmgr_item_id_symbol"
+        app:layout_constraintEnd_toStartOf="@id/icons_container"
+        app:layout_constraintTop_toBottomOf="@id/waypoints_container">
+
+        <TextView
+            android:id="@+id/trackmgr_item_trackpoints"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/trackmgr_trackpoints_count"
+            android:textStyle="bold"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:duplicateParentState="false"/>
+
+        <TextView
+            android:id="@+id/trackmgr_item_tps"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:minWidth="40dp"
+            android:text="{y}"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:duplicateParentState="false"/>
+    </LinearLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/icons_container"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:gravity="center">
+        android:layout_height="0dp"
+        android:minWidth="32dp"
+        android:paddingHorizontal="4dp"
+        android:stateListAnimator="@null"
+        android:duplicateParentState="false"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
 
         <ImageView
             android:id="@+id/trackmgr_item_statusicon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="4dp"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:padding="2dp"
             android:contentDescription="@string/acc.track_status"
-            android:src="@android:drawable/presence_online"/>
+            android:src="@android:drawable/presence_online"
+            android:background="@null"
+            android:stateListAnimator="@null"
+            android:duplicateParentState="false"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/trackmgr_item_upload_statusicon"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
 
         <ImageView
             android:id="@+id/trackmgr_item_upload_statusicon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="4dp"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:padding="2dp"
             android:contentDescription="@string/acc.upload_status"
-            android:src="@android:drawable/stat_sys_upload_done"/>
-    </LinearLayout>
-</LinearLayout>
+            android:src="@android:drawable/stat_sys_upload_done"
+            android:background="@null"
+            android:stateListAnimator="@null"
+            android:duplicateParentState="false"
+            app:layout_constraintTop_toBottomOf="@id/trackmgr_item_statusicon"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/trackmanager.xml
+++ b/app/src/main/res/layout/trackmanager.xml
@@ -3,7 +3,8 @@
 	xmlns:tools="http://schemas.android.com/tools"
 	android:orientation="vertical"
 	android:layout_height="fill_parent"
-	android:layout_width="fill_parent">
+	android:layout_width="fill_parent"
+	android:fitsSystemWindows="true">
 
 	<androidx.appcompat.widget.Toolbar
 		android:id="@+id/my_toolbar"

--- a/app/src/main/res/layout/waypointlist_item.xml
+++ b/app/src/main/res/layout/waypointlist_item.xml
@@ -1,14 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout 
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
 
-<RelativeLayout android:layout_width="fill_parent"
-	android:layout_height="fill_parent" xmlns:android="http://schemas.android.com/apk/res/android">
-	<TextView android:layout_height="wrap_content"
-		android:id="@+id/wplist_item_name" android:text="{name}"
-		android:layout_width="wrap_content" style="@android:style/TextAppearance.Large"></TextView>
-	<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" android:text="{timestamp}" android:id="@+id/wplist_item_timestamp" android:layout_below="@+id/wplist_item_location" android:layout_alignBaseline="@+id/wplist_item_name" android:layout_alignParentRight="true" android:layout_alignRight="@+id/wplist_item_name" android:layout_marginRight="10dp"></TextView><TextView android:layout_height="wrap_content"
-		android:layout_width="wrap_content"
-		android:id="@+id/wplist_item_location"
-		android:text="{location}" android:layout_below="@+id/wplist_item_name" android:layout_alignParentRight="true" android:layout_marginRight="10dp"></TextView>
+    <TextView
+        android:id="@+id/wplist_item_name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="{name}"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/wplist_item_timestamp"/>
 
-	
-</RelativeLayout>
+    <TextView
+        android:id="@+id/wplist_item_timestamp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="{timestamp}"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <TextView
+        android:id="@+id/wplist_item_location"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="{location}"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        app:layout_constraintTop_toBottomOf="@id/wplist_item_name"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/waypointlist_item.xml
+++ b/app/src/main/res/layout/waypointlist_item.xml
@@ -4,7 +4,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="8dp">
+    android:minHeight="72dp"
+    android:padding="8dp"
+    android:stateListAnimator="@null"
+    android:background="?android:attr/selectableItemBackground">
 
     <TextView
         android:id="@+id/wplist_item_name"
@@ -12,9 +15,11 @@
         android:layout_height="wrap_content"
         android:text="{name}"
         android:textAppearance="?android:attr/textAppearanceLarge"
+        android:layout_marginBottom="4dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/wplist_item_timestamp"/>
+        app:layout_constraintEnd_toStartOf="@id/wplist_item_timestamp"
+        android:duplicateParentState="false"/>
 
     <TextView
         android:id="@+id/wplist_item_timestamp"
@@ -22,8 +27,10 @@
         android:layout_height="wrap_content"
         android:text="{timestamp}"
         android:textAppearance="?android:attr/textAppearanceSmall"
+        android:layout_marginStart="8dp"
         app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintEnd_toEndOf="parent"
+        android:duplicateParentState="false"/>
 
     <TextView
         android:id="@+id/wplist_item_location"
@@ -31,7 +38,17 @@
         android:layout_height="wrap_content"
         android:text="{location}"
         android:textAppearance="?android:attr/textAppearanceSmall"
+        android:layout_marginTop="4dp"
         app:layout_constraintTop_toBottomOf="@id/wplist_item_name"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintEnd_toEndOf="parent"
+        android:duplicateParentState="false"/>
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="wplist_item_location"/>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Changes
- Added `android:fitsSystemWindows="true"` to handle system window insets properly
- Ensures content is properly displayed without being obscured by the status bar

## Testing
Verified on:
- Android 15 (API 35) - Fixed
- Android 7.1 (API 25) - No regression