### PR TITLE
fix: Add fitsSystemWindows to handle edge-to-edge behavior in Android 15

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/Preferences.java
+++ b/app/src/main/java/net/osmtracker/activity/Preferences.java
@@ -27,6 +27,7 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.ListView;
 
 
 /**
@@ -63,6 +64,10 @@ public class Preferences extends PreferenceActivity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		addPreferencesFromResource(R.xml.preferences);
+		ListView listView = getListView();
+		listView.setFitsSystemWindows(true);
+		listView.setClipToPadding(false);
+		listView.setPadding(0, 48, 0, 0);
 
 		// Set summary of some preferences to their actual values
 		// and register a change listener to set again the summary in case of change

--- a/app/src/main/java/net/osmtracker/activity/WaypointList.java
+++ b/app/src/main/java/net/osmtracker/activity/WaypointList.java
@@ -38,4 +38,18 @@ public class WaypointList extends ListActivity {
 		super.onResume();
 	}
 
+	@Override
+	protected void onPause() {
+		CursorAdapter adapter = (CursorAdapter) getListAdapter();
+		if (adapter != null) {
+			// Properly close the adapter cursor
+			Cursor cursor = adapter.getCursor();
+			stopManagingCursor(cursor);
+			cursor.close();
+			setListAdapter(null);
+		}
+
+		super.onPause();
+	}
+
 }

--- a/app/src/main/java/net/osmtracker/activity/WaypointList.java
+++ b/app/src/main/java/net/osmtracker/activity/WaypointList.java
@@ -20,11 +20,10 @@ public class WaypointList extends ListActivity {
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-
 		ListView listView = getListView();
 		listView.setFitsSystemWindows(true);
 		listView.setClipToPadding(false);
-		listView.setPadding(0, 48, 0, 0); // Ajusta el 48dp según necesites
+		listView.setPadding(0, 48, 0, 0);
 	}
 
 	@Override

--- a/app/src/main/java/net/osmtracker/activity/WaypointList.java
+++ b/app/src/main/java/net/osmtracker/activity/WaypointList.java
@@ -5,7 +5,9 @@ import net.osmtracker.db.WaypointListAdapter;
 
 import android.app.ListActivity;
 import android.database.Cursor;
+import android.os.Bundle;
 import android.widget.CursorAdapter;
+import android.widget.ListView;
 
 /**
  * Activity that lists the previous waypoints tracked by the user.
@@ -16,29 +18,25 @@ import android.widget.CursorAdapter;
 public class WaypointList extends ListActivity {
 
 	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+
+		ListView listView = getListView();
+		listView.setFitsSystemWindows(true);
+		listView.setClipToPadding(false);
+		listView.setPadding(0, 48, 0, 0); // Ajusta el 48dp según necesites
+	}
+
+	@Override
 	protected void onResume() {
 		Long trackId = getIntent().getExtras().getLong(TrackContentProvider.Schema.COL_TRACK_ID);
-		
+
 		Cursor cursor = getContentResolver().query(TrackContentProvider.waypointsUri(trackId),
 				null, null, null, TrackContentProvider.Schema.COL_TIMESTAMP + " desc");
 		startManagingCursor(cursor);
 		setListAdapter(new WaypointListAdapter(WaypointList.this, cursor));
-		
+
 		super.onResume();
-	}
-
-	@Override
-	protected void onPause() {
-		CursorAdapter adapter = (CursorAdapter) getListAdapter();
-		if (adapter != null) {
-			// Properly close the adapter cursor
-			Cursor cursor = adapter.getCursor();
-			stopManagingCursor(cursor);
-			cursor.close();
-			setListAdapter(null);
-		}
-
-		super.onPause();
 	}
 
 }

--- a/app/src/main/res/layout-iw/waypointlist_item.xml
+++ b/app/src/main/res/layout-iw/waypointlist_item.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<RelativeLayout android:layout_width="fill_parent"
-	android:layout_height="fill_parent" xmlns:android="http://schemas.android.com/apk/res/android">
+<RelativeLayout
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
 	<TextView android:layout_width="wrap_content" android:id="@+id/wplist_item_timestamp" android:layout_height="wrap_content" android:text="{timestamp}" android:layout_below="@+id/wplist_item_location" android:layout_alignParentLeft="true" android:layout_marginLeft="10dp"></TextView>
 	<TextView style="@android:style/TextAppearance.Large" android:layout_width="wrap_content" android:id="@+id/wplist_item_name" android:layout_height="wrap_content" android:text="{name}" android:layout_alignParentTop="true" android:layout_alignParentRight="true"></TextView>
 	<TextView android:layout_width="wrap_content" android:id="@+id/wplist_item_location" android:layout_height="wrap_content" android:text="{location}" android:layout_below="@+id/wplist_item_name" android:layout_alignParentLeft="true" android:layout_marginLeft="10dp"></TextView>

--- a/app/src/main/res/layout/about.xml
+++ b/app/src/main/res/layout/about.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="10dp">
+    android:padding="10dp"
+    android:fitsSystemWindows="true">
 
     <LinearLayout
         android:id="@+id/about_header"

--- a/app/src/main/res/layout/available_layouts.xml
+++ b/app/src/main/res/layout/available_layouts.xml
@@ -1,7 +1,8 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fillViewport="true">
+    android:fillViewport="true"
+    android:fitsSystemWindows="true">
 
     <LinearLayout
         android:id="@+id/root_layout"

--- a/app/src/main/res/layout/buttons_presets.xml
+++ b/app/src/main/res/layout/buttons_presets.xml
@@ -5,7 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:id="@+id/buttons_presets"
-    android:paddingTop="4dp">
+    android:paddingTop="4dp"
+    android:fitsSystemWindows="true">
 
     <TextView
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/displaytrackmap.xml
+++ b/app/src/main/res/layout/displaytrackmap.xml
@@ -2,7 +2,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:fitsSystemWindows="true">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/github_repository_settings.xml
+++ b/app/src/main/res/layout/github_repository_settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent" android:padding="7dp">
+    android:layout_height="match_parent" android:padding="7dp" android:fitsSystemWindows="true">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/gpsstatus_record.xml
+++ b/app/src/main/res/layout/gpsstatus_record.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent" >
+    android:layout_height="fill_parent" 
+    android:fitsSystemWindows="true">
 
     <TextView
         android:id="@+id/gpsstatus_record_tvHeading"

--- a/app/src/main/res/layout/osm_upload.xml
+++ b/app/src/main/res/layout/osm_upload.xml
@@ -2,7 +2,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:orientation="vertical" >
+    android:orientation="vertical" 
+    android:fitsSystemWindows="true">
 
     <LinearLayout
         android:id="@+id/trackdetail_buttons"

--- a/app/src/main/res/layout/tracklogger.xml
+++ b/app/src/main/res/layout/tracklogger.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="fill_parent"
-	android:orientation="vertical" android:layout_height="fill_parent">
+	android:orientation="vertical" android:layout_height="fill_parent" android:fitsSystemWindows="true">
 	<net.osmtracker.layout.GpsStatusRecord
 		android:id="@+id/gpsStatus" android:layout_width="fill_parent"
 		android:layout_height="wrap_content" />

--- a/app/src/main/res/layout/trackmanager.xml
+++ b/app/src/main/res/layout/trackmanager.xml
@@ -3,7 +3,8 @@
 	xmlns:tools="http://schemas.android.com/tools"
 	android:orientation="vertical"
 	android:layout_height="fill_parent"
-	android:layout_width="fill_parent">
+	android:layout_width="fill_parent"
+	android:fitsSystemWindows="true">
 
 	<androidx.appcompat.widget.Toolbar
 		android:id="@+id/my_toolbar"

--- a/app/src/main/res/layout/waypointlist_item.xml
+++ b/app/src/main/res/layout/waypointlist_item.xml
@@ -1,14 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<RelativeLayout android:layout_width="fill_parent"
-	android:layout_height="fill_parent" xmlns:android="http://schemas.android.com/apk/res/android" android:fitsSystemWindows="true">
+<RelativeLayout 
+	xmlns:android="http://schemas.android.com/apk/res/android" 
+	android:layout_width="match_parent"
+	android:layout_height="match_parent">
+
 	<TextView android:layout_height="wrap_content"
-		android:id="@+id/wplist_item_name" android:text="{name}"
-		android:layout_width="wrap_content" style="@android:style/TextAppearance.Large"></TextView>
-	<TextView android:layout_height="wrap_content" android:layout_width="wrap_content" android:text="{timestamp}" android:id="@+id/wplist_item_timestamp" android:layout_below="@+id/wplist_item_location" android:layout_alignBaseline="@+id/wplist_item_name" android:layout_alignParentRight="true" android:layout_alignRight="@+id/wplist_item_name" android:layout_marginRight="10dp"></TextView><TextView android:layout_height="wrap_content"
+		android:id="@+id/wplist_item_name" 
+		android:text="{name}"
+		android:layout_width="wrap_content" 
+		style="@android:style/TextAppearance.Large">
+	</TextView>
+	<TextView 
+		android:layout_height="wrap_content" 
+		android:layout_width="wrap_content" 
+		android:text="{timestamp}" 
+		android:id="@+id/wplist_item_timestamp" 
+		android:layout_below="@+id/wplist_item_location" 
+		android:layout_alignBaseline="@+id/wplist_item_name" 
+		android:layout_alignParentRight="true" 
+		android:layout_alignRight="@+id/wplist_item_name" 
+		android:layout_marginRight="10dp">
+	</TextView>
+	<TextView 
+		android:layout_height="wrap_content"
 		android:layout_width="wrap_content"
 		android:id="@+id/wplist_item_location"
-		android:text="{location}" android:layout_below="@+id/wplist_item_name" android:layout_alignParentRight="true" android:layout_marginRight="10dp"></TextView>
+		android:text="{location}" 
+		android:layout_below="@+id/wplist_item_name" 
+		android:layout_alignParentRight="true" 
+		android:layout_marginRight="10dp">
+	</TextView>
 
-	
 </RelativeLayout>

--- a/app/src/main/res/layout/waypointlist_item.xml
+++ b/app/src/main/res/layout/waypointlist_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout android:layout_width="fill_parent"
-	android:layout_height="fill_parent" xmlns:android="http://schemas.android.com/apk/res/android">
+	android:layout_height="fill_parent" xmlns:android="http://schemas.android.com/apk/res/android" android:fitsSystemWindows="true">
 	<TextView android:layout_height="wrap_content"
 		android:id="@+id/wplist_item_name" android:text="{name}"
 		android:layout_width="wrap_content" style="@android:style/TextAppearance.Large"></TextView>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
 	<ListPreference
 		android:title="@string/prefs_voicerec_duration"
 		android:key="voicerec.duration"
 		android:entryValues="@array/prefs_voicerec_durations"
 		android:defaultValue="2"
-		android:entries="@array/prefs_voicerec_durations" />
+		android:entries="@array/prefs_voicerec_durations"/>
 	<CheckBoxPreference
 		android:key="sound_enabled"
 		android:title="@string/prefs_sound_enabled"
@@ -125,7 +129,5 @@
 			android:entries="@array/prefs_ui_orientation_options_keys"
 			android:entryValues="@array/prefs_ui_orientation_options_values" />
 	</PreferenceCategory>
-
-
 
 </PreferenceScreen>


### PR DESCRIPTION
## Changes
- Added `android:fitsSystemWindows="true"` to handle system window insets properly
- Ensures content is properly displayed without being obscured by the status bar

## Testing
Verified on:
- Android 15 (API 35) - Fixed
- Android 7.1 (API 25) - No regression