### PR TITLE
Fix extra dot in zip filename

### DIFF
--- a/app/src/main/java/net/osmtracker/gpx/ZipHelper.java
+++ b/app/src/main/java/net/osmtracker/gpx/ZipHelper.java
@@ -29,7 +29,7 @@ public class ZipHelper {
 
         String name = fileGPX.getName();
         File zipFile = new File(context.getCacheDir(),
-                name.substring(0, name.length() - 3) + DataHelper.EXTENSION_ZIP);
+                name.substring(0, name.lastIndexOf(".")) + DataHelper.EXTENSION_ZIP);
 
         File traceFilesDirectory = DataHelper.getTrackDirectory(trackId, context);
 


### PR DESCRIPTION
The last dot in the filename is used to get the name without the file extension.
* Solved: #511 