### PR TITLE
Fix inconsistent tag behavior for exported tracks to ensure Play Store update consistency

### DIFF
--- a/app/src/main/java/net/osmtracker/OSMTracker.java
+++ b/app/src/main/java/net/osmtracker/OSMTracker.java
@@ -66,7 +66,7 @@ public class OSMTracker {
 		public final static String VAL_OUTPUT_FILENAME_DATE_NAME = "date_name";
 		public final static String VAL_OUTPUT_FILENAME_DATE = "date";
 		public final static String VAL_OUTPUT_FILENAME = VAL_OUTPUT_FILENAME_NAME_DATE;
-		public final static String VAL_OUTPUT_FILENAME_LABEL = "OSMTracker";
+		public final static String VAL_OUTPUT_FILENAME_LABEL = "";
 
 		public final static String VAL_OUTPUT_ACCURACY_NONE = "none";
 		public final static String VAL_OUTPUT_ACCURACY_WPT_NAME = "wpt_name";

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -64,7 +64,7 @@
 		<ListPreference android:key="gpx.filename" android:defaultValue="name_date" android:summary="@string/prefs_output_filename_summary"
 			android:title="@string/prefs_output_filename" android:entryValues="@array/prefs_output_filename_values"
 			android:entries="@array/prefs_output_filename_keys" />
-		<EditTextPreference android:key="gpx.filename.label" android:defaultValue="" android:summary="@string/prefs_output_filename_labe l_summary"
+		<EditTextPreference android:key="gpx.filename.label" android:defaultValue="" android:summary="@string/prefs_output_filename_label_summary"
 			android:title="@string/prefs_output_filename_label"/>
 		<ListPreference
 			android:key="gpx.accuracy"
@@ -114,13 +114,6 @@
 			android:title="@string/prefs_displaytrack_osm"
 			android:summary="@string/prefs_displaytrack_osm_summary"
 			android:defaultValue="false" />
-		<!--<ListPreference
-			android:entries="@array/prefs_map_tile_keys"
-			android:title="@string/prefs_map_tile"
-			android:entryValues="@array/prefs_map_tile_values"
-			android:key="ui.map.tile"
-			android:summary="@string/prefs_map_tile_summary"
-			android:defaultValue="MAPNIK" />-->
 		<ListPreference
 			android:defaultValue="none"
 			android:key="ui.orientation"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -64,7 +64,7 @@
 		<ListPreference android:key="gpx.filename" android:defaultValue="name_date" android:summary="@string/prefs_output_filename_summary"
 			android:title="@string/prefs_output_filename" android:entryValues="@array/prefs_output_filename_values"
 			android:entries="@array/prefs_output_filename_keys" />
-		<EditTextPreference android:key="gpx.filename.label" android:defaultValue="OSMTracker" android:summary="@string/prefs_output_filename_label_summary"
+		<EditTextPreference android:key="gpx.filename.label" android:defaultValue="" android:summary="@string/prefs_output_filename_labe l_summary"
 			android:title="@string/prefs_output_filename_label"/>
 		<ListPreference
 			android:key="gpx.accuracy"

--- a/app/src/test/java/net/osmtracker/gpx/ExportToStorageTaskTest.java
+++ b/app/src/test/java/net/osmtracker/gpx/ExportToStorageTaskTest.java
@@ -83,7 +83,9 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = "MyTrack_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
+        String expectedFilename = "MyTrack";
+        if(!(Preferences.VAL_OUTPUT_FILENAME_LABEL.equals("")))expectedFilename += "_";
+        expectedFilename += Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -94,7 +96,9 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME_DATE;
 
-        String expectedFilename = "MyTrack_2000-01-02_03-04-05_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
+        String expectedFilename = "MyTrack_2000-01-02_03-04-05";
+        if(!(Preferences.VAL_OUTPUT_FILENAME_LABEL.equals(""))) expectedFilename += "_";
+        expectedFilename += Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -105,7 +109,9 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_DATE_NAME;
 
-        String expectedFilename = "2000-01-02_03-04-05_MyTrack_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
+        String expectedFilename = "2000-01-02_03-04-05_MyTrack";
+        if(!(Preferences.VAL_OUTPUT_FILENAME_LABEL.equals(""))) expectedFilename += "_";
+        expectedFilename += Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -116,7 +122,9 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_DATE;
 
-        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
+        String expectedFilename = "2000-01-02_03-04-05";
+        if(!(Preferences.VAL_OUTPUT_FILENAME_LABEL.equals(""))) expectedFilename += "_";
+        expectedFilename += Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -127,7 +135,9 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = ";M_y_T_r_a_c_k;_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
+        String expectedFilename = ";M_y_T_r_a_c_k;";
+        if(!(Preferences.VAL_OUTPUT_FILENAME_LABEL.equals(""))) expectedFilename += "_";
+        expectedFilename += Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -138,7 +148,9 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME;
 
-        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx"; // Must fallback to use the start date
+        String expectedFilename = "2000-01-02_03-04-05";
+        if(!(Preferences.VAL_OUTPUT_FILENAME_LABEL.equals(""))) expectedFilename += "_";
+        expectedFilename += Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }
@@ -149,7 +161,9 @@ public class ExportToStorageTaskTest {
         Date trackStartDate = createDateFrom(2000, 1, 2, 3, 4, 5);
         String preferenceSetting = Preferences.VAL_OUTPUT_FILENAME_NAME_DATE;
 
-        String expectedFilename = "2000-01-02_03-04-05_"+Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx"; // Must fallback to use the start date
+        String expectedFilename = "2000-01-02_03-04-05";
+        if(!(Preferences.VAL_OUTPUT_FILENAME_LABEL.equals(""))) expectedFilename += "_";
+        expectedFilename += Preferences.VAL_OUTPUT_FILENAME_LABEL+".gpx";
 
         doTestBuildGPXFilename(trackNameInDatabase, preferenceSetting, trackStartDate.getTime(), expectedFilename);
     }


### PR DESCRIPTION
This PR addresses the issue where the tag assigned to exported tracks is inconsistent, leading to unexpected behavior for users who update the app from the Play Store. By setting the tag to "", exported and shared tracks will behave consistently across updates, ensuring a seamless experience for users.

Changes Made
* Set the tag for exported tracks to "" to ensure it remains consistent and doesn't change unexpectedly after updates.
* Verified that users updating the app via the Play Store will not experience any changes in track export behavior.

solution to the issue:

* #515 

note: the test has also been updated  