### PR TITLE
fix: Waypoint preview does not work

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/WaypointList.java
+++ b/app/src/main/java/net/osmtracker/activity/WaypointList.java
@@ -2,6 +2,7 @@ package net.osmtracker.activity;
 
 import android.app.AlertDialog;
 import android.app.ListActivity;
+import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
@@ -140,7 +141,12 @@ public class WaypointList extends ListActivity {
 					}
 
 					if (intent.resolveActivity(getPackageManager()) != null) {
-						startActivity(intent);
+						try{
+							startActivity(intent);
+						} catch (ActivityNotFoundException e) {
+							// Handle the case where no app can handle the intent
+							// this means the user has not installed an app that can handle the file type
+						}
 					}
 				}
 				alert.dismiss();

--- a/app/src/main/java/net/osmtracker/activity/WaypointList.java
+++ b/app/src/main/java/net/osmtracker/activity/WaypointList.java
@@ -16,6 +16,7 @@ import android.widget.Button;
 import android.widget.CursorAdapter;
 import android.widget.EditText;
 import android.widget.ListView;
+import android.widget.Toast;
 import androidx.core.content.FileProvider;
 import net.osmtracker.R;
 import net.osmtracker.db.DataHelper;
@@ -140,13 +141,13 @@ public class WaypointList extends ListActivity {
 						intent.setDataAndType(fileUri, DataHelper.MIME_TYPE_AUDIO);
 					}
 
-					if (intent.resolveActivity(getPackageManager()) != null) {
-						try{
-							startActivity(intent);
-						} catch (ActivityNotFoundException e) {
-							// Handle the case where no app can handle the intent
-							// this means the user has not installed an app that can handle the file type
-						}
+					try{
+						startActivity(intent);
+					} catch (ActivityNotFoundException e) {
+						// Handle the case where no app can handle the intent
+						// this means the user has not installed an app that can handle the file type
+						//Log.e(TAG, "No app found to handle the file type: " + filePath, e);
+						Toast.makeText(WaypointList.this, getString(R.string.no_app_to_handle_file_type), Toast.LENGTH_LONG).show();
 					}
 				}
 				alert.dismiss();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,4 +222,5 @@
     <string name="app_intro_slide2_title">Happy tracking 🗺 😎</string>
     <string name="app_intro_slide2_description">OSMTracker for Android will use your GPS location to record trackpoints and waypoints, even when the App is running in background.
 \nYour data is not used to support ads.</string>
+    <string name="no_app_to_handle_file_type">No application was found to open this file.</string>
 </resources>


### PR DESCRIPTION
This pr fixes the bug that happens in android 13, that does not allow to visualize the images because it does not have an application that can read the images.

Issue:
* #554 