### PR TITLE
An easy way to upload the same filename to GitHub

### DIFF
--- a/app/src/main/java/net/osmtracker/util/Callback.java
+++ b/app/src/main/java/net/osmtracker/util/Callback.java
@@ -1,0 +1,17 @@
+package net.osmtracker.util;
+
+/**
+ * A generic callback interface used for asynchronous operations.
+ * Implementations of this interface should define how to handle the result
+ * of an asynchronous task.
+ */
+public interface Callback {
+    /**
+     * Called when the asynchronous operation is completed.
+     * Implementations should handle the provided result accordingly.
+     *
+     * @param result The result of the operation, which may be {@code null} if an error occurs.
+     * @return A string value that may be used by the calling function, if applicable.
+     */
+    String onResult(String result);
+}

--- a/app/src/main/java/net/osmtracker/util/GitHubUtils.java
+++ b/app/src/main/java/net/osmtracker/util/GitHubUtils.java
@@ -1,0 +1,75 @@
+package net.osmtracker.util;
+
+import android.os.AsyncTask;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Utility class for interacting with the GitHub API.
+ * Provides methods to retrieve file information and manage file uploads.
+ *
+ * <p>This class includes methods to:
+ * <ul>
+ *   <li>Generate a unique filename within a GitHub repository.</li>
+ *   <li>Retrieve the SHA hash of a file stored in a GitHub repository.</li>
+ * </ul>
+ * </p>
+ *
+ * <p>It requires a valid GitHub authentication token for API requests.</p>
+ */
+public class GitHubUtils {
+    /**
+     * Retrieves the SHA hash of a file in a GitHub repository.
+     * If the file does not exist, it returns {@code null}.
+     *
+     * @param repoOwner   The owner of the repository (user or organization).
+     * @param repoName    The name of the GitHub repository.
+     * @param repoFilePath The file path in the repository.
+     * @param token       The GitHub authentication token with appropriate permissions.
+     * @return The SHA hash of the file if it exists, or {@code null} if the file is not found.
+     * @throws IOException   If an I/O error occurs while making the request.
+     * @throws JSONException If an error occurs while parsing the JSON response.
+     */
+    public static void getFileSHAAsync(String repoOwner, String repoName, String repoFilePath, String token, Callback callback) {
+        new AsyncTask<Void, Void, String>() {
+            @Override
+            protected String doInBackground(Void... voids) {
+                try {
+                    String apiUrl = "https://api.github.com/repos/" + repoOwner + "/" + repoName + "/contents/" + repoFilePath;
+                    System.out.println("Fetching SHA: " + apiUrl);
+                    HttpURLConnection connection = (HttpURLConnection) new URL(apiUrl).openConnection();
+                    connection.setRequestMethod("GET");
+                    connection.setRequestProperty("Authorization", "Bearer " + token);
+                    connection.setRequestProperty("Accept", "application/vnd.github.v3+json");
+
+                    if (connection.getResponseCode() == 200) {
+                        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+                        StringBuilder response = new StringBuilder();
+                        String line;
+                        while ((line = reader.readLine()) != null) {
+                            response.append(line);
+                        }
+                        reader.close();
+                        JSONObject jsonResponse = new JSONObject(response.toString());
+                        return jsonResponse.getString("sha");
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                return null;
+            }
+
+            @Override
+            protected void onPostExecute(String sha) {
+                callback.onResult(sha); // Return result via callback
+            }
+        }.execute();
+    }
+}

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -40,7 +40,6 @@
   <string name="trackmgr_contextmenu_export">Exportar</string>
   <string name="trackmgr_contextmenu_share">Compartir</string>
   <string name="trackmgr_contextmenu_osm_upload">Subir a OpenStreetMap</string>
-  <string name="trackmgr_contextmenu_github_upload">Subir a GitHub</string>
   <string name="trackmgr_contextmenu_display">Visualizar</string>
   <string name="trackmgr_contextmenu_details">Detalles</string>
   <string name="trackmgr_contextmenu_title">Traza #{0}</string>
@@ -196,53 +195,6 @@
   <string name="github_repository_settings_branch_name">Nombre de la rama: </string>
   <string name="github_repository_settings_valid_server">Repositorio de GitHub válido</string>
   <string name="github_repository_settings_invalid_server">Repositorio de GitHub inválido</string>
-
-  <!-- Upload to GitHub functionality-->
-  <string name="successfully_created">Creado exitosamente</string>
-  <string name="error_creating">Error al crear</string>
-  <string name="db_error">Error en base de datos</string>
-  <string name="successfully_saved">Guardado exitosamente</string>
-  <string name="saving_error">Error al guardar</string>
-  <string name="pr_status">Estado del pull request: </string>
-  <string name="repository_information_error">Error al obtener información del repositorio</string>
-  <string name="successfully_uploaded">Subido exitosamente</string>"
-  <string name="error_uploading">Error al subir</string>
-  <string name="gpx_file_read_error">Error al leer el archivo GPX</string>
-  <string name="gpx_file_not_found">No se encontró el archivo GPX</string>
-  <string name="uploading_file">Subiendo: </string>
-  <string name="item_selected">Selecciono el elemento: </string>
-  <string name="github_repository_private">Privado: </string>
-  <string name="github_no_repository_name">Indique el nombre del repositorio</string>
-  <string name="error_field_required">Campo requerido</string>
-  <!-- GitHubConfig -->
-  <string name="github_config_btn">Configurar</string>
-  <string name="github_token_placeholder">Token de GitHub:</string>
-  <string name="github_get_token_btn">Obtener token</string>
-  <string name="github_token_guide_title">Cómo obtener un token de GitHub:</string>
-  <string name="how_to_get_ghToken_guide_step_1">1. Haga clic en el botón para abrir el sitio web de GitHub y crear un token. Inicie sesión con su cuenta de GitHub si es necesario.</string>
-  <string name="how_to_get_ghToken_guide_step_2">2. Seleccione \"Tokens (Clásicos)\" y haga clic en el botón \"Generar nuevo token\".</string>
-  <string name="how_to_get_ghToken_guide_step_3">3. Asigne un nombre descriptivo a su token.</string>
-  <string name="how_to_get_ghToken_guide_step_4">4. Seleccione una fecha de expiración. Recomendamos \"Sin expiración\" para evitar repetir este paso.</string>
-  <string name="how_to_get_ghToken_guide_step_5">5. Seleccione los permisos que desee otorgar al token (OSMTracker solo necesita el permiso de repositorio).</string>
-  <string name="how_to_get_ghToken_guide_step_6">6. Haga clic en el botón \"Generar token\".</string>
-  <string name="how_to_get_ghToken_guide_step_7">7. Copie el token generado y péguelo en el campo \"Token de GitHub\".</string>
-  <string name="how_to_get_ghToken_guide_note">⚠️ Puede guardar en blanco para borrar sus credenciales.</string>
-  <!-- GitHubUpload -->
-  <string name="upload_to_github_description">Mensaje del commit:</string>
-  <string name="upload_to_github_create_fork">Crear\nfork</string>
-  <string name="upload_to_github_open_pull_request">Abrir pull request</string>
-  <string name="upload_to_github_select_repo">Seleccione un repositorio</string>
-  <string name="upload_to_github_create_repository">Crear repositorio</string>
-  <string name="upload_to_github_commit_btn">Hacer commit</string>
-  <string name="upload_to_github_configure">Configurar</string>
-  <!-- GitHubNewFork -->
-  <string name="upload_to_github_forked_repo_owner">Usuario del repositorio original</string>
-  <string name="upload_to_github_forked_repo_name">Nombre del repositorio original</string>
-  <string name="create">Crear</string>
-  <!-- GitHubPullRequest -->
-  <string name="upload_to_github_pr_title">Título del Pull Request</string>
-  <string name="upload_to_github_pr_description">Descripción del Pull Request</string>
-  <!-- END Upload to GitHub functionality-->
 
   <!--App Introduction-->
   <string name="app_intro">Introducción a OSMTracker para Android ™</string>


### PR DESCRIPTION
[comment]: # (Thank you for your contribution! Please fill out the following details to help us review your pull request.)

### Description
[comment]: # (Provide a clear explanation of the changes in this PR)
[comment]: # (Include information about what problem it solves, how it is implemented, and if it affects UI/API)
This PR introduces the capacity to upload the trace zip file to a GitHub repository without the need to change the filename.
Example: if we upload a file with the following:

* **Trace name**: myTrace.gpx
* **Zip file name**: myTrace.zip

In the first attempt to upload the trace, the file will have `myTrace.zip` as name, but in the second attempt his name will change to `myTrace(1).zip`. Finally the target repository will have two files `myTrace.zip` and `myTrace(1).zip`.

_Note: the number inside the parenthesis is calculated according to the total files with the same name in the repository._


### Related issues
[comment]: # (Link to the original bug report or related work in list format, if applicable)
[comment]: # (* Closes: #number)
[comment]: # (* Related to: #number)
* Related to: #460
* Related to: #361
* Related to: #344
* Related to: #85

##

### Pull Request Checklist
[comment]: # (Please confirm the following before submitting your PR)
[comment]: # (To check a task please put a "x" inside the `[]`)
[comment]: # ([ ] : not done)
[comment]: # ([x] : done)
[comment]: # (Make sure how your PR looks clicking the "Preview" tab at the top of this editor)

- [X] The PR is proposed to the proper branch.
- [X] The changes have been tested on the target Android API and minimum Android API.
- [ ] Automated tests have been added (if applicable).
- [ ] The feature is well documented.
- [X] There is a reference to the original bug report and related work.
