### PR TITLE
Create multiple track segments when tracking is stopped and later res…

### DIFF
--- a/app/src/main/java/net/osmtracker/db/DataHelper.java
+++ b/app/src/main/java/net/osmtracker/db/DataHelper.java
@@ -127,7 +127,7 @@ public class DataHelper {
 	 * @param pressure
 	 *            atmospheric pressure
 	 */
-	public void track(long trackId, Location location, float azimuth, int accuracy, float pressure) {
+	public void track(long trackId, Location location, float azimuth, int accuracy, float pressure, boolean newSeg, long segId) {
 		Log.v(TAG, "Tracking (trackId=" + trackId + ") location: " + location + " azimuth: " + azimuth + ", accuracy: " + accuracy);
 		ContentValues values = new ContentValues();
 		values.put(TrackContentProvider.Schema.COL_TRACK_ID, trackId);
@@ -161,6 +161,8 @@ public class DataHelper {
 			values.put(TrackContentProvider.Schema.COL_ATMOSPHERIC_PRESSURE, pressure);
 		}
 
+		values.put(TrackContentProvider.Schema.COL_SEG_ID, segId);
+		
 		Uri trackUri = ContentUris.withAppendedId(TrackContentProvider.CONTENT_URI_TRACK, trackId);
 		contentResolver.insert(Uri.withAppendedPath(trackUri, TrackContentProvider.Schema.TBL_TRACKPOINT + "s"), values);
 	}

--- a/app/src/main/java/net/osmtracker/db/DatabaseHelper.java
+++ b/app/src/main/java/net/osmtracker/db/DatabaseHelper.java
@@ -39,7 +39,9 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 		+ TrackContentProvider.Schema.COL_TIMESTAMP + " long not null,"
 		+ TrackContentProvider.Schema.COL_COMPASS + " double null,"
 		+ TrackContentProvider.Schema.COL_COMPASS_ACCURACY + " integer null,"
-		+ TrackContentProvider.Schema.COL_ATMOSPHERIC_PRESSURE + " double null" + ")";
+		+ TrackContentProvider.Schema.COL_ATMOSPHERIC_PRESSURE + " double null,"
+		+ TrackContentProvider.Schema.COL_SEG_ID + " integer not null default 0"
+		+ ")";
 
 	/**
 	 * SQL for creating index TRACKPOINT_idx (track id)
@@ -125,7 +127,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 	 * v17: add TBL_TRACKPOINT.COL_ATMOSPHERIC_PRESSURE and TBL_WAYPOINT.COL_ATMOSPHERIC_PRESSURE
 	 *</pre>
 	 */
-	private static final int DB_VERSION = 17;
+	private static final int DB_VERSION = 18;
 
 	private Context context;
 
@@ -181,6 +183,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 		case 16:
 			db.execSQL("alter table " + TrackContentProvider.Schema.TBL_TRACKPOINT + " add column " + TrackContentProvider.Schema.COL_ATMOSPHERIC_PRESSURE + " double null");
 			db.execSQL("alter table " + TrackContentProvider.Schema.TBL_WAYPOINT + " add column " + TrackContentProvider.Schema.COL_ATMOSPHERIC_PRESSURE + " double null");
+		case 17:
+			db.execSQL("alter table "+TrackContentProvider.Schema.TBL_TRACKPOINT + " add column " + TrackContentProvider.Schema.COL_SEG_ID + " integer default 0");
 		}
 	}
 

--- a/app/src/main/java/net/osmtracker/db/TrackContentProvider.java
+++ b/app/src/main/java/net/osmtracker/db/TrackContentProvider.java
@@ -76,7 +76,8 @@ public class TrackContentProvider extends ContentProvider {
 		Schema.COL_OSM_VISIBILITY,
 		Schema.COL_START_DATE,
 		"count(" + Schema.TBL_TRACKPOINT + "." + Schema.COL_ID + ") as " + Schema.COL_TRACKPOINT_COUNT,
-		"(SELECT count("+Schema.TBL_WAYPOINT+"."+Schema.COL_TRACK_ID+") FROM "+Schema.TBL_WAYPOINT+" WHERE "+Schema.TBL_WAYPOINT+"."+Schema.COL_TRACK_ID+" = " + Schema.TBL_TRACK + "." + Schema.COL_ID + ") as " + Schema.COL_WAYPOINT_COUNT
+		"(SELECT count("+Schema.TBL_WAYPOINT+"."+Schema.COL_TRACK_ID+") FROM "+Schema.TBL_WAYPOINT+" WHERE "+Schema.TBL_WAYPOINT+"."+Schema.COL_TRACK_ID+" = " + Schema.TBL_TRACK + "." + Schema.COL_ID + ") as " + Schema.COL_WAYPOINT_COUNT,
+		"(SELECT max("+Schema.TBL_TRACKPOINT+"."+Schema.COL_SEG_ID+") FROM "+Schema.TBL_TRACKPOINT+" WHERE "+Schema.TBL_TRACKPOINT+"."+Schema.COL_TRACK_ID+" = " + Schema.TBL_TRACK + "." + Schema.COL_ID + ") as " + Schema.COL_MAX_SEG_ID
 	};
 
 	/**
@@ -495,10 +496,13 @@ public class TrackContentProvider extends ContentProvider {
 		public static final String COL_COMPASS = "compass_heading";
 		public static final String COL_COMPASS_ACCURACY = "compass_accuracy";
 		public static final String COL_ATMOSPHERIC_PRESSURE = "atmospheric_pressure";
-		
+
+		public static final String COL_SEG_ID = "segment_id";
+
 		// virtual colums that are used in some sqls but dont exist in database
 		public static final String COL_TRACKPOINT_COUNT = "tp_count";
 		public static final String COL_WAYPOINT_COUNT = "wp_count";
+		public static final String COL_MAX_SEG_ID = "max_segment_id";
 		
 		// Codes for UriMatcher
 		public static final int URI_CODE_TRACK = 3;

--- a/app/src/main/java/net/osmtracker/db/model/Track.java
+++ b/app/src/main/java/net/osmtracker/db/model/Track.java
@@ -51,7 +51,7 @@ public class Track {
 	private String description;
 	private OSMVisibility visibility;
 	private List<String> tags = new ArrayList<String>();
-	private int tpCount, wpCount;
+	private int tpCount, wpCount, maxSegId;
 	private long trackDate;
 	private long trackId;
 	
@@ -93,6 +93,8 @@ public class Track {
 		
 		out.wpCount = tc.getInt(tc.getColumnIndex(TrackContentProvider.Schema.COL_WAYPOINT_COUNT));
 		
+		int maxSegIdIdx = tc.getColumnIndex(TrackContentProvider.Schema.COL_MAX_SEG_ID);
+		out.maxSegId = tc.isNull(maxSegIdIdx) ? 0 :tc.getInt(maxSegIdIdx);
 		if(withExtraInformation){
 			out.readExtraInformation();
 		}
@@ -145,6 +147,10 @@ public class Track {
 		this.wpCount = wpCount;
 	}
 
+	public void setMaxSegId(int maxSegId) {
+		this.maxSegId = maxSegId;
+	}
+
 	public void setTracktDate(long tracktDate) {
 		this.trackDate = tracktDate;
 	}
@@ -187,6 +193,10 @@ public class Track {
 		return wpCount;
 	}
 	
+	public Integer getMaxSegId() {
+		return maxSegId;
+	}
+
 	public Integer getTpCount() {
 		return tpCount;
 	}

--- a/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
+++ b/app/src/main/java/net/osmtracker/gpx/ExportTrackTask.java
@@ -347,8 +347,16 @@ public abstract class ExportTrackTask extends AsyncTask<Void, Long, Boolean> {
 		fw.write("\t\t" + "<trkseg>" + "\n");
 
 		int i=0;
+		int prevSegId=-1;
 		for(c.moveToFirst(); !c.isAfterLast(); c.moveToNext(),i++) {
 			StringBuffer out = new StringBuffer();
+			int segId = c.getInt(c.getColumnIndex(TrackContentProvider.Schema.COL_SEG_ID));
+			if(prevSegId != -1 && segId != prevSegId) {
+				fw.write("\t\t" + "</trkseg>" + "\n");
+				fw.write("\t\t" + "<trkseg>" + "\n");
+			}
+			prevSegId = segId;
+			
 			out.append("\t\t\t" + "<trkpt lat=\""
 					+ c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LATITUDE)) + "\" "
 					+ "lon=\"" + c.getDouble(c.getColumnIndex(TrackContentProvider.Schema.COL_LONGITUDE)) + "\">" + "\n");

--- a/app/src/main/java/net/osmtracker/overlay/Polylines.java
+++ b/app/src/main/java/net/osmtracker/overlay/Polylines.java
@@ -1,0 +1,61 @@
+package net.osmtracker.overlay;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osmdroid.util.GeoPoint;
+import org.osmdroid.views.MapView;
+import org.osmdroid.views.overlay.Polyline;
+
+import android.graphics.Paint;
+
+/**
+ * Collection of Polylines, useful to draw interrupted paths
+ */
+public class Polylines {
+	private int color;
+	private float width;
+	private MapView osmView;
+	private boolean havePoint;
+	
+	private int curIdx=0;
+	
+	private List<Polyline> polylines = new ArrayList<Polyline>();
+
+	private void addPolyline() {
+		Polyline polyline = new Polyline();
+		Paint paint = polyline.getOutlinePaint();
+                paint.setColor(color);
+                paint.setStrokeWidth(width);
+
+		polylines.add(polyline);
+		osmView.getOverlayManager().add(polyline);
+	}
+
+	public void clear() {
+		for(Polyline polyline : polylines)
+			polyline.setPoints(new ArrayList<>());
+		curIdx=0;
+	}
+
+	public Polylines(int color, float width, MapView osmView) {
+		this.color=color;
+		this.width=width;
+		this.osmView = osmView;
+		addPolyline();
+		havePoint=false;
+	}
+
+	public void addPoint(GeoPoint gp) {
+		if(curIdx >= polylines.size())
+			addPolyline();
+		polylines.get(curIdx).addPoint(gp);
+		havePoint=true;
+	}
+
+	public void nextSegment() {
+		if(havePoint)
+			curIdx++;
+		havePoint=false;
+	}
+}

--- a/app/src/main/java/net/osmtracker/service/gps/GPSLogger.java
+++ b/app/src/main/java/net/osmtracker/service/gps/GPSLogger.java
@@ -6,6 +6,8 @@ import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
+import android.content.ContentResolver;
+import android.content.ContentUris;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -24,11 +26,14 @@ import android.util.Log;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
 
+import android.database.Cursor;
+
 import net.osmtracker.OSMTracker;
 import net.osmtracker.R;
 import net.osmtracker.activity.TrackLogger;
 import net.osmtracker.db.DataHelper;
 import net.osmtracker.db.TrackContentProvider;
+import net.osmtracker.db.model.Track;
 import net.osmtracker.listener.PressureListener;
 import net.osmtracker.listener.SensorListener;
 
@@ -83,6 +88,11 @@ public class GPSLogger extends Service implements LocationListener {
 	 */
 	private long currentTrackId = -1;
 
+    	/**
+	 * Current Segment ID
+	 */
+	private long currentSegmentId = -1;
+
 	/**
 	 * the timestamp of the last GPS fix we used
 	 */
@@ -103,6 +113,8 @@ public class GPSLogger extends Service implements LocationListener {
 	 * sensor for atmospheric pressure
 	 */
 	private PressureListener pressureListener = new PressureListener();
+
+	private boolean newSeg = false;
 
 	/**
 	 * Receives Intent for way point tracking, and stop/start logging.
@@ -130,7 +142,8 @@ public class GPSLogger extends Service implements LocationListener {
 							dataHelper.wayPoint(trackId, lastLocation, name, link, uuid, sensorListener.getAzimuth(), sensorListener.getAccuracy(), pressureListener.getPressure());
 
 							// If there is a waypoint in the track, there should also be a trackpoint
-							dataHelper.track(currentTrackId, lastLocation, sensorListener.getAzimuth(), sensorListener.getAccuracy(), pressureListener.getPressure());
+							dataHelper.track(currentTrackId, lastLocation, sensorListener.getAzimuth(), sensorListener.getAccuracy(), pressureListener.getPressure(), newSeg, currentSegmentId);
+							newSeg = false;
 						}
 					}
 				}
@@ -159,6 +172,7 @@ public class GPSLogger extends Service implements LocationListener {
 					dataHelper.deleteWayPoint(uuid, filePath);
 				}
 			} else if (OSMTracker.INTENT_START_TRACKING.equals(intent.getAction())) {
+				newSeg = true;
 				Bundle extras = intent.getExtras();
 				if (extras != null) {
 					Long trackId = extras.getLong(TrackContentProvider.Schema.COL_TRACK_ID);
@@ -284,12 +298,31 @@ public class GPSLogger extends Service implements LocationListener {
 		super.onDestroy();
 	}
 
+	private long getSegIdFor(long trackId) {
+		ContentResolver cr = getContentResolver();
+		try(Cursor cursor =
+		    cr.query(ContentUris.withAppendedId(TrackContentProvider.CONTENT_URI_TRACK, trackId),
+			     null, null, null, null)) {
+
+			if (! cursor.moveToFirst())	{
+				Log.v(TAG, "Track "+trackId+" not found");
+				return 0;  // <--- Early return ---
+			}
+
+			return Track
+				.build(trackId, cursor, cr, true)
+				.getMaxSegId();
+		}
+	}
+
 	/**
 	 * Start GPS tracking.
 	 */
 	private void startTracking(long trackId) {
 		currentTrackId = trackId;
-		Log.v(TAG, "Starting track logging for track #" + trackId);
+		currentSegmentId = getSegIdFor(trackId)+1;
+		Log.v(TAG, "Starting track logging for track #" + trackId +
+		      "/" + currentSegmentId);
 		// Refresh notification with correct Track ID
 		NotificationManager nmgr = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 		nmgr.notify(NOTIFICATION_ID, getNotification());
@@ -318,7 +351,8 @@ public class GPSLogger extends Service implements LocationListener {
 			lastLocation = location;
 			
 			if (isTracking) {
-				dataHelper.track(currentTrackId, location, sensorListener.getAzimuth(), sensorListener.getAccuracy(), pressureListener.getPressure());
+				dataHelper.track(currentTrackId, location, sensorListener.getAzimuth(), sensorListener.getAccuracy(), pressureListener.getPressure(), newSeg, currentSegmentId);
+				newSeg = false;
 			}
 		}
 	}


### PR DESCRIPTION
…umed to avoid criss-crossing lines on map

[comment]: # (Thank you for your contribution! Please fill out the following details to help us review your pull request.)

### Description
[comment]: # (Provide a clear explanation of the changes in this PR)
[comment]: # (Include information about what problem it solves, how it is implemented, and if it affects UI/API)

Hi,

This pull pull request is an update of (#310) ("Track segments" when tracking is stopped and later resumed)

This PR resolves the conflicts with the dev branch (newest osmdroid that uses Polylines) which prevented the eal

It also associates consecutive segment numbers with each segment, rather than marking the first point of each segment.

Thx for merging,

Alain


### Related issues
[comment]: # (Link to the original bug report or related work in list format, if applicable)
[comment]: # (* Closes: #number)
[comment]: # (* Related to: #number)

https://github.com/labexp/osmtracker-android/issues/295

##

### Pull Request Checklist
[comment]: # (Please confirm the following before submitting your PR)
[comment]: # (To check a task please put a "x" inside the `[]`)
[comment]: # ([ ] : not done)
[comment]: # ([x] : done)
[comment]: # (Make sure how your PR looks clicking the "Preview" tab at the top of this editor)

- [x] The PR is proposed to the proper branch.
- [ ] The changes have been tested on the target Android API and minimum Android API.
- [ ] Automated tests have been added (if applicable).
- [ ] The feature is well documented.
- [x] There is a reference to the original bug report and related work.
