### PR TITLE
Allow again to chose map tile provider. CyclOSM and OpenTopo are now …

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
+++ b/app/src/main/java/net/osmtracker/activity/DisplayTrackMap.java
@@ -26,6 +26,9 @@ import net.osmtracker.overlay.WayPointsOverlay;
 import org.osmdroid.api.IMapController;
 import org.osmdroid.config.Configuration;
 import org.osmdroid.tileprovider.tilesource.TileSourceFactory;
+import org.osmdroid.tileprovider.tilesource.ITileSource;
+import org.osmdroid.tileprovider.tilesource.XYTileSource;
+
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.CustomZoomButtonsController;
 import org.osmdroid.views.MapView;
@@ -231,8 +234,7 @@ public class DisplayTrackMap extends Activity {
 	public void selectTileSource() {
 		String mapTile = prefs.getString(OSMTracker.Preferences.KEY_UI_MAP_TILE, OSMTracker.Preferences.VAL_UI_MAP_TILE_MAPNIK);
 		Log.e("TileMapName active", mapTile);
-		//osmView.setTileSource(selectMapTile(mapTile));
-		osmView.setTileSource(TileSourceFactory.DEFAULT_TILE_SOURCE);
+		osmView.setTileSource(selectMapTile(mapTile));
 	}
 
 	/**
@@ -243,6 +245,16 @@ public class DisplayTrackMap extends Activity {
 	}
 
 
+	static {
+		TileSourceFactory.addTileSource(new XYTileSource("CyclOSM",
+								 0, 18, 256, ".png", 
+								 new String[] {
+									 "https://a.tile-cyclosm.openstreetmap.fr/cyclosm/",
+									 "https://b.tile-cyclosm.openstreetmap.fr/cyclosm/",
+									 "https://c.tile-cyclosm.openstreetmap.fr/cyclosm/"},
+								 "© OpenStreetMap contributors"));
+	}
+
 //	/**
 //	 * Returns a ITileSource for the map according to the selected mapTile
 //	 * String. The default is mapnik.
@@ -250,16 +262,15 @@ public class DisplayTrackMap extends Activity {
 //	 * @param mapTile String that is the name of the tile provider
 //	 * @return ITileSource with the selected Tile-Source
 //	 */
-//	private ITileSource selectMapTile(String mapTile) {
-//		try {
-//			Field f = TileSourceFactory.class.getField(mapTile);
-//			return (ITileSource) f.get(null);
-//		} catch (Exception e) {
-//			Log.e(TAG, "Invalid tile source '"+mapTile+"'", e);
-//			Log.e(TAG, "Default tile source selected: '" + TileSourceFactory.DEFAULT_TILE_SOURCE.name() +"'");
-//			return TileSourceFactory.DEFAULT_TILE_SOURCE;
-//		}
-//	}
+	private ITileSource selectMapTile(String mapTile) {
+		try {
+			return TileSourceFactory.getTileSource(mapTile);
+		} catch (Exception e) {
+			Log.e(TAG, "Invalid tile source '"+mapTile+"'", e);
+			Log.e(TAG, "Default tile source selected: '" + TileSourceFactory.DEFAULT_TILE_SOURCE.name() +"'");
+			return TileSourceFactory.DEFAULT_TILE_SOURCE;
+		}
+	}
 
 
 	@Override

--- a/app/src/main/res/values-ar/strings-preferences.xml
+++ b/app/src/main/res/values-ar/strings-preferences.xml
@@ -80,7 +80,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>خريطة الدراجات</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>لا شيء</item>

--- a/app/src/main/res/values-b+sr+Latn/strings-preferences.xml
+++ b/app/src/main/res/values-b+sr+Latn/strings-preferences.xml
@@ -74,7 +74,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Bez usmerenja</item>

--- a/app/src/main/res/values-ca/strings-preferences.xml
+++ b/app/src/main/res/values-ca/strings-preferences.xml
@@ -76,7 +76,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Cap</item>

--- a/app/src/main/res/values-cs-rCZ/strings-preferences.xml
+++ b/app/src/main/res/values-cs-rCZ/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Nikde</item>

--- a/app/src/main/res/values-da/strings-preferences.xml
+++ b/app/src/main/res/values-da/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Deaktiveret</item>

--- a/app/src/main/res/values-de/strings-preferences.xml
+++ b/app/src/main/res/values-de/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>kein Export</item>

--- a/app/src/main/res/values-el/strings-preferences.xml
+++ b/app/src/main/res/values-el/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Κανένα</item>

--- a/app/src/main/res/values-es/strings-preferences.xml
+++ b/app/src/main/res/values-es/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Ninguno</item>

--- a/app/src/main/res/values-fa-rIR/strings-preferences.xml
+++ b/app/src/main/res/values-fa-rIR/strings-preferences.xml
@@ -73,7 +73,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>خالی</item>

--- a/app/src/main/res/values-fi/strings-preferences.xml
+++ b/app/src/main/res/values-fi/strings-preferences.xml
@@ -74,7 +74,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Pyöräilykartta</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Ei lainkaan</item>

--- a/app/src/main/res/values-fr/strings-preferences.xml
+++ b/app/src/main/res/values-fr/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Aucun</item>

--- a/app/src/main/res/values-gl/strings-preferences.xml
+++ b/app/src/main/res/values-gl/strings-preferences.xml
@@ -74,7 +74,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>Abrir MapQuest</item>
+    <item>Abrir yMapQuest</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Non</item>

--- a/app/src/main/res/values-he/strings-preferences.xml
+++ b/app/src/main/res/values-he/strings-preferences.xml
@@ -73,7 +73,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>ללא שמירה</item>

--- a/app/src/main/res/values-hr/strings-preferences.xml
+++ b/app/src/main/res/values-hr/strings-preferences.xml
@@ -67,7 +67,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Ništa</item>

--- a/app/src/main/res/values-hu/strings-preferences.xml
+++ b/app/src/main/res/values-hu/strings-preferences.xml
@@ -88,7 +88,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Biciklis térkép</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Semmi</item>

--- a/app/src/main/res/values-id/strings-preferences.xml
+++ b/app/src/main/res/values-id/strings-preferences.xml
@@ -74,7 +74,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Nihil</item>

--- a/app/src/main/res/values-it/strings-preferences.xml
+++ b/app/src/main/res/values-it/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Nessuno</item>

--- a/app/src/main/res/values-ja/strings-preferences.xml
+++ b/app/src/main/res/values-ja/strings-preferences.xml
@@ -86,7 +86,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>なし</item>

--- a/app/src/main/res/values-ko/strings-preferences.xml
+++ b/app/src/main/res/values-ko/strings-preferences.xml
@@ -80,7 +80,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>사이클 지도</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>없음</item>

--- a/app/src/main/res/values-lt/strings-preferences.xml
+++ b/app/src/main/res/values-lt/strings-preferences.xml
@@ -18,6 +18,6 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
 </resources>

--- a/app/src/main/res/values-lv/strings-preferences.xml
+++ b/app/src/main/res/values-lv/strings-preferences.xml
@@ -79,7 +79,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Nekur</item>

--- a/app/src/main/res/values-nb/strings-preferences.xml
+++ b/app/src/main/res/values-nb/strings-preferences.xml
@@ -74,7 +74,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Ingen</item>

--- a/app/src/main/res/values-nl/strings-preferences.xml
+++ b/app/src/main/res/values-nl/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Geen</item>

--- a/app/src/main/res/values-pl/strings-preferences.xml
+++ b/app/src/main/res/values-pl/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Mapa rowerowa</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Brak</item>

--- a/app/src/main/res/values-pt-rBR/strings-preferences.xml
+++ b/app/src/main/res/values-pt-rBR/strings-preferences.xml
@@ -84,7 +84,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Nenhum</item>

--- a/app/src/main/res/values-pt-rPT/strings-preferences.xml
+++ b/app/src/main/res/values-pt-rPT/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Não exportar</item>

--- a/app/src/main/res/values-ru/strings-preferences.xml
+++ b/app/src/main/res/values-ru/strings-preferences.xml
@@ -86,7 +86,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Нет</item>

--- a/app/src/main/res/values-sk/strings-preferences.xml
+++ b/app/src/main/res/values-sk/strings-preferences.xml
@@ -79,7 +79,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Žiadne</item>

--- a/app/src/main/res/values-sl/strings-preferences.xml
+++ b/app/src/main/res/values-sl/strings-preferences.xml
@@ -74,7 +74,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Brez</item>

--- a/app/src/main/res/values-sr/strings-preferences.xml
+++ b/app/src/main/res/values-sr/strings-preferences.xml
@@ -86,7 +86,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Без усмерења</item>

--- a/app/src/main/res/values-sv/strings-preferences.xml
+++ b/app/src/main/res/values-sv/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Ingen</item>

--- a/app/src/main/res/values-tr/strings-preferences.xml
+++ b/app/src/main/res/values-tr/strings-preferences.xml
@@ -86,7 +86,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Hiçbiri</item>

--- a/app/src/main/res/values-uk/strings-preferences.xml
+++ b/app/src/main/res/values-uk/strings-preferences.xml
@@ -79,7 +79,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Ні</item>

--- a/app/src/main/res/values-vi/strings-preferences.xml
+++ b/app/src/main/res/values-vi/strings-preferences.xml
@@ -74,7 +74,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Bản đồ Xe đạp</item>
-    <item>MapQuest Mở</item>
+    <item>yMapQuest Mở</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>Không xuất</item>

--- a/app/src/main/res/values-zh-rCN/strings-preferences.xml
+++ b/app/src/main/res/values-zh-rCN/strings-preferences.xml
@@ -73,7 +73,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>不保存</item>

--- a/app/src/main/res/values-zh-rTW/strings-preferences.xml
+++ b/app/src/main/res/values-zh-rTW/strings-preferences.xml
@@ -89,7 +89,7 @@
   <string-array name="prefs_map_tile_keys">
     <item>Mapnik</item>
     <item>Cycle Map</item>
-    <item>MapQuest Open</item>
+    <item>OpenTopo</item>
   </string-array>
   <string-array name="prefs_compass_heading_keys">
     <item>無</item>

--- a/app/src/main/res/values/strings-preferences.xml
+++ b/app/src/main/res/values/strings-preferences.xml
@@ -111,7 +111,7 @@
 	<string-array name="prefs_map_tile_keys">
 		<item>Mapnik</item>
 		<item>Cycle Map</item>
-		<item>MapQuest Open</item>
+		<item>OpenTopo</item>
 	</string-array>
 	<string-array name="prefs_compass_heading_keys">
 		<item >None</item>

--- a/app/src/main/res/values/values-preferences.xml
+++ b/app/src/main/res/values/values-preferences.xml
@@ -44,9 +44,9 @@
 	</string-array>
 	
 	<string-array name="prefs_map_tile_values">
-		<item>MAPNIK</item>
-		<item>CYCLEMAP</item>
-		<item>MAPQUESTOSM</item>
+		<item>Mapnik</item>
+		<item>CyclOSM</item>
+		<item>OpenTopoMap</item>
 	</string-array>
 	<string-array name="prefs_compass_heading_values">
 		<item >none</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -116,6 +116,13 @@
 			android:defaultValue="false" />
 		<ListPreference
 			android:defaultValue="none"
+			android:key="ui.map.tile"
+			android:title="@string/prefs_map_tile"
+			android:summary="@string/prefs_map_tile_summary"
+			android:entries="@array/prefs_map_tile_keys"
+			android:entryValues="@array/prefs_map_tile_values" />
+		<ListPreference
+			android:defaultValue="none"
 			android:key="ui.orientation"
 			android:title="@string/prefs_ui_orientation"
 			android:summary="@string/prefs_ui_orientation_summary"


### PR DESCRIPTION
[comment]: # (Thank you for your contribution! Please fill out the following details to help us review your pull request.)

### Description
[comment]: # (Provide a clear explanation of the changes in this PR)
[comment]: # (Include information about what problem it solves, how it is implemented, and if it affects UI/API)

This pull request enables Map tile provider choice again, which was removed by pull request 210, as the maps proposed back then are no longer (freely) available.

2 new maps are now available to chose from:
 - CyclOSM cycle map. Does not need an API key, unlike the previous cycle map.
 - OpenTopo map, especially useful when hiking thanks to its contour lines

Both maps are proposed on the www.openstreetmap.org site, so chances are that they will stay around for a while.

Maps are now chosen by string, rather than by static field name, in order to allow using maps not (yet) included by default in TileSourceFactory (such as CyclOSM)

### Related issues
[comment]: # (Link to the original bug report or related work in list format, if applicable)
[comment]: # (* Closes: #number)
[comment]: # (* Related to: #number)

Closes: #96 #125 

##

### Pull Request Checklist
[comment]: # (Please confirm the following before submitting your PR)
[comment]: # (To check a task please put a "x" inside the `[]`)
[comment]: # ([ ] : not done)
[comment]: # ([x] : done)
[comment]: # (Make sure how your PR looks clicking the "Preview" tab at the top of this editor)

- [x] The PR is proposed to the proper branch.
- [x] The changes have been tested on the target Android API and minimum Android API.
- [ ] Automated tests have been added (if applicable).
- [x] The feature is well documented.
- [x] There is a reference to the original bug report and related work.
