### PR TITLE
Add Telegram group link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Here is a screenshot of the main screen with its default buttons. You can [custo
 - Contributions are welcome, please visit our [contributor guide](https://github.com/labexp/osmtracker-android/blob/master/CONTRIBUTING.md)
 - Translations can be done on [Transifex](https://explore.transifex.com/labexp/osmtracker-android/)
 
+## Community & Support 🌐
+
+Join our **Telegram group** to connect with users, developers, translators, and contributors:  
+👉 [https://t.me/OSMTracker](https://t.me/OSMTracker)
+
+Use this space for real-time discussions, guidance, and support.  
+For bug reports or feature requests, continue using the [GitHub Issues](https://github.com/labexp/osmtracker-android/issues) tracker.
+
+
 ## Note 📝
 
 OSMTracker for Android™ official source code repository is [https://github.com/labexp/osmtracker-android](https://github.com/labexp/osmtracker-android).


### PR DESCRIPTION
### Description
This PR adds a **Community & Support** section to the README with a link to the **OSMTracker Telegram group**.  
It provides a space for users, contributors, translators, and developers to join the community for real-time discussions and support.  
GitHub Issues will remain the primary channel for bug reports and feature requests.

### Related issues
Related to the pr:
* #602

### Pull Request Checklist
- [x] The PR is proposed to the proper branch.
- [ ] The changes have been tested on the target Android API and minimum Android API (not applicable).
- [ ] Automated tests have been added (not applicable).
- [ ] The feature is well documented (not applicable)..
- [ ] There is a reference to the original bug report or related work (not aplicable).
