### PR TITLE
Add visible labels to track detail fields to prevent confusión, Fix issue 609

### DIFF
--- a/app/src/main/res/layout/trackdetail_fields.xml
+++ b/app/src/main/res/layout/trackdetail_fields.xml
@@ -1,38 +1,67 @@
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    tools:parentTag="android.widget.LinearLayout">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/trackdetail_name_and_title" />
 
     <EditText
         android:id="@+id/trackdetail_item_name"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="5dp"
+        android:layout_marginStart="5dp"
+        android:layout_marginEnd="5dp"
         android:hint="@string/trackdetail_name"
         android:inputType="text"
+        android:minHeight="48dp"
         android:singleLine="true" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/trackdetail_description" />
 
     <EditText
         android:id="@+id/trackdetail_item_description"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/trackdetail_item_name"
-        android:layout_margin="5dp"
+        android:layout_marginStart="5dp"
+        android:layout_marginEnd="5dp"
         android:hint="@string/trackdetail_description"
         android:inputType="text"
+        android:minHeight="48dp"
         android:singleLine="false" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/trackdetail_tags" />
 
     <EditText
         android:id="@+id/trackdetail_item_tags"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/trackdetail_item_description"
-        android:layout_margin="5dp"
+        android:layout_marginStart="5dp"
+        android:layout_marginEnd="5dp"
         android:hint="@string/trackdetail_tags"
         android:inputType="text"
+        android:minHeight="48dp"
         android:singleLine="true" />
 
     <Spinner
         android:id="@+id/trackdetail_item_osm_visibility"
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/trackdetail_item_tags" />
+        android:layout_marginTop="8dp"
+        android:minHeight="48dp" />
 
 </merge>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="trackdetail_osm_upload_notyet">(Not uploaded yet)</string>
     <string name="trackdetail_export_display">Display</string>
     <string name="trackdetail_name">Name</string>
+    <string name="trackdetail_name_and_title">Name and title</string>
     <string name="trackdetail_description">Description</string>
     <string name="trackdetail_tags">Tags (comma separated)</string>
     <string name="trackdetail_description_mandatory">You must enter a description</string>


### PR DESCRIPTION
The previous design used hints to label the name, description, and tags fields. These hints disappeared when the fields were filled in automatically, causing confusion for the user about the purpose of each field.

This change introduces permanent text labels (TextView) above each input field. This ensures that the function of each field is always visible, significantly improving the usability of the screen.

Fixes #609

[comment]: # (Thank you for your contribution! Please fill out the following details to help us review your pull request.)

### Description
[comment]: # (Provide a clear explanation of the changes in this PR)
[comment]: # (Include information about what problem it solves, how it is implemented, and if it affects UI/API)

The previous design used hints to label the name, description, and tags fields. These hints would disappear when the fields were auto-filled, causing user confusion about the purpose of each input box.

This change resolves the issue by introducing permanent text labels (TextView) placed vertically above each corresponding input field (EditText). This ensures that the function of each field is always visible, significantly improving the usability and clarity of the screen.


### Related issues
[comment]: # (Link to the original bug report or related work in list format, if applicable)
[comment]: # (* Closes: #number)
[comment]: # (* Related to: #number)
* #609 

##

### Pull Request Checklist
[comment]: # (Please confirm the following before submitting your PR)
[comment]: # (To check a task please put a "x" inside the `[]`)
[comment]: # ([ ] : not done)
[comment]: # ([x] : done)
[comment]: # (Make sure how your PR looks clicking the "Preview" tab at the top of this editor)

- [x] The PR is proposed to the proper branch.
- [ ] The changes have been tested on the target Android API and minimum Android API.
- [ ] Automated tests have been added (if applicable).
- [ ] The feature is well documented.
- [x] There is a reference to the original bug report and related work.
