### PR TITLE
Fix: Remove trackdetail_name_and_title string to clarify filename configuration

### DIFF
--- a/app/src/main/res/layout/trackdetail_fields.xml
+++ b/app/src/main/res/layout/trackdetail_fields.xml
@@ -8,7 +8,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="5dp"
         android:layout_marginTop="8dp"
-        android:text="@string/trackdetail_name_and_title" />
+        android:text="@string/trackdetail_name" />
 
     <EditText
         android:id="@+id/trackdetail_item_name"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,7 +68,6 @@
     <string name="trackdetail_osm_upload_notyet">(Not uploaded yet)</string>
     <string name="trackdetail_export_display">Display</string>
     <string name="trackdetail_name">Name</string>
-    <string name="trackdetail_name_and_title">Name and title</string>
     <string name="trackdetail_description">Description</string>
     <string name="trackdetail_tags">Tags (comma separated)</string>
     <string name="trackdetail_description_mandatory">You must enter a description</string>


### PR DESCRIPTION
[comment]: # (Thank you for your contribution! Please fill out the following details to help us review your pull request.)

### Description
[comment]: # (Provide a clear explanation of the changes in this PR)
[comment]: # (Include information about what problem it solves, how it is implemented, and if it affects UI/API)

This pull request removes the trackdetail_name_and_title string from the strings.xml file. Initially, this string included "Name and title," which caused confusion as the term "title" is not used consistently throughout the app. The filename configuration allows for customization, such as using the "date and start time" format, making the inclusion of "title" unnecessary and potentially misleading.

### Related issues
[comment]: # (Link to the original bug report or related work in list format, if applicable)
[comment]: # (* Closes: #number)
[comment]: # (* Related to: #number)
* #609 

##

### Pull Request Checklist
[comment]: # (Please confirm the following before submitting your PR)
[comment]: # (To check a task please put a "x" inside the `[]`)
[comment]: # ([ ] : not done)
[comment]: # ([x] : done)
[comment]: # (Make sure how your PR looks clicking the "Preview" tab at the top of this editor)

- [x] The PR is proposed to the proper branch.
- [ ] The changes have been tested on the target Android API and minimum Android API.
- [ ] Automated tests have been added (if applicable).
- [ ] The feature is well documented.
- [ ] There is a reference to the original bug report and related work.
