### PR TITLE
fix: resolve text overlap in osm_upload layout

### DIFF
--- a/app/src/main/res/layout/osm_upload.xml
+++ b/app/src/main/res/layout/osm_upload.xml
@@ -32,9 +32,16 @@
             android:text="@string/tracklogger_btnBack" />
     </LinearLayout>
 
-    <include
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content"
-        layout="@layout/trackdetail_fields" />
+    <LinearLayout
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:layout_above="@id/trackdetail_buttons"
+            android:orientation="vertical" >
+
+        <include
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                layout="@layout/trackdetail_fields" />
+    </LinearLayout>
 
 </RelativeLayout>


### PR DESCRIPTION
[comment]: # (Thank you for your contribution! Please fill out the following details to help us review your pull request.)

### Description
[comment]: # (Provide a clear explanation of the changes in this PR)
[comment]: # (Include information about what problem it solves, how it is implemented, and if it affects UI/API)
Fixing UI bug that overlapped the text when the user entered the osm upload screen. With bug:
![photo_4947243262443981687_w](https://github.com/user-attachments/assets/d8cd3cc7-bc31-4891-8ac1-aac7b8efa4ba)
Fixed:
<img width="255" height="457" alt="image" src="https://github.com/user-attachments/assets/64496277-f09d-41aa-ae12-bb235ef14f9b" />


### Related issues
[comment]: # (Link to the original bug report or related work in list format, if applicable)
[comment]: # (* Closes: #number)
[comment]: # (* Related to: #number)

##

### Pull Request Checklist
[comment]: # (Please confirm the following before submitting your PR)
[comment]: # (To check a task please put a "x" inside the `[]`)
[comment]: # ([ ] : not done)
[comment]: # ([x] : done)
[comment]: # (Make sure how your PR looks clicking the "Preview" tab at the top of this editor)

- [X] The PR is proposed to the proper branch.
- [ ] The changes have been tested on the target Android API and minimum Android API.
- [ ] Automated tests have been added (if applicable).
- [ ] The feature is well documented.
- [ ] There is a reference to the original bug report and related work.
