### PR TITLE
Add a button to restore default values in logging interval' and 'logging distance' preferences

### DIFF
--- a/app/src/androidTest/java/net/osmtracker/activity/PreferencesTest.java
+++ b/app/src/androidTest/java/net/osmtracker/activity/PreferencesTest.java
@@ -123,6 +123,39 @@ public class PreferencesTest {
 	}
 
 	/**
+	 * Test that the Reset button in numeric preferences restores the default value.
+	 */
+	@Test
+	public void testResetButtonResetsValue() {
+		String title = context.getString(R.string.prefs_gps_logging_interval);
+		String suffix = context.getString(R.string.prefs_gps_logging_interval_seconds);
+		String defaultValue = OSMTracker.Preferences.VAL_GPS_LOGGING_INTERVAL;
+
+		scrollToAndClick(title);
+
+		// Set a custom value "50"
+		onView(withId(android.R.id.edit)).perform(clearText(), typeText("50"));
+		onView(withText(android.R.string.ok)).perform(click());
+
+		// Verify custom value is set
+		onView(ViewMatchers.isAssignableFrom(RecyclerView.class))
+				.check(matches(hasDescendant(withText(stringContainsInOrder(Arrays.asList("50",
+						suffix))))));
+
+		// Reopen dialog
+		scrollToAndClick(title);
+
+		// Click the Reset button (Neutral button)
+		onView(withText(R.string.prefs_reset_default_value)).perform(click());
+
+		// Verify value is back to default "0"
+		onView(ViewMatchers.isAssignableFrom(RecyclerView.class))
+				.check(matches(hasDescendant(withText(stringContainsInOrder(Arrays.asList(
+						defaultValue,
+						suffix))))));
+	}
+
+	/**
 	 * Test ListPreference custom summary logic (Screen Orientation)
 	 * Should show "Selected Value. \n ..." (don't check for the 2nd line of the summary)
 	 */

--- a/app/src/main/res/values/strings-preferences.xml
+++ b/app/src/main/res/values/strings-preferences.xml
@@ -124,4 +124,5 @@
 	<string name="prefs_compass_heading">Export compass heading</string>
 	<string name="prefs_compass_heading_summary">Defines if and how the compass data should be exported to the GPX file</string>
 
+    <string name="prefs_reset_default_value">Reset default value</string>
 </resources>


### PR DESCRIPTION


[comment]: # (Thank you for your contribution! Please fill out the following details to help us review your pull request.)
# 📝 Add a button to restore defaults 'logging interval' and 'logging distance'

## 🛠️ Issue
- Closes #345


## 🖼️ Screenshots (if applicable)

![Screenshot_20260102-074346_OSMTracker for Android_](https://github.com/user-attachments/assets/e7db2e7d-82ea-4247-806d-0ddcbd1d939c)




## ✅ Pull Request Checklist
[comment]: # (Please confirm the following before submitting your PR)
[comment]: # (To check a task please put a "x" inside the `[]`)
[comment]: # ([ ] : not done)
[comment]: # ([x] : done)
[comment]: # (Make sure how your PR looks clicking the "Preview" tab at the top of this editor)

- [X] The PR is proposed to the DEVELOP branch.
- [ ] The changes have been tested on the target Android API and minimum Android API.
- [X] Automated tests have been added (if applicable).
- [X] The feature is well documented.
- [X] There is a reference to the original ISSUE and related work.
