### PR TITLE
Add Signing to nightly APK

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,12 +51,34 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Signing Keystore
+        run: |                 
+          # 1. Decode nightly keystore secret
+          echo "${{ secrets.NIGHTLY_KEYSTORE }}" | base64 -d > /tmp/nightly-keystore.jks
+          echo "Keystore created in /tmp/nightly-keystore.jks"
+          
+          # Verify
+          echo "✅ Keystore created in: /tmp/nightly-keystore.jks"
+          ls -la /tmp/nightly-keystore.jks
+          echo "ks_path=/tmp/nightly-keystore.jks" >> $GITHUB_OUTPUT
+          
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
 
       - name: Build with Gradle
-        run: ./gradlew assembleDebug --stacktrace
+        run: |        
+          ./gradlew assembleDebug --stacktrace \
+            -Pandroid.injected.signing.store.file="/tmp/nightly-keystore.jks" \
+            -Pandroid.injected.signing.store.password="${{ secrets.KEYSTORE_PASSWORD }}" \
+            -Pandroid.injected.signing.key.alias="${{ secrets.KEY_ALIAS }}" \
+            -Pandroid.injected.signing.key.password="${{ secrets.KEY_PASSWORD }}"
+
+      - name: Cleanup Keystore
+        run: |
+          echo "Cleaning keystore..."
+          rm -f app/nightly-keystore.jks
+          echo "✅ Keystore removed"
 
       - name: Rename output APK
         run: |


### PR DESCRIPTION

# 📝 CI nightly workflow improvement

## 🛠️ Issue
- Closes #466


## 📖 Description
[comment]: # (Provide a clear explanation of the changes in this PR)
Generate signed APKs for nightly releases compatible among themselves. This change allows us to check backward compatibility.

