### PR TITLE
Fix a backwards compatibility bug in preferences 

### DIFF
--- a/app/src/main/java/net/osmtracker/activity/Preferences.java
+++ b/app/src/main/java/net/osmtracker/activity/Preferences.java
@@ -349,8 +349,15 @@ public class Preferences extends AppCompatActivity {
 			listPref.setSummaryProvider(preference -> {
 				ListPreference lp = (ListPreference) preference;
 				CharSequence entry = lp.getEntry();
-				// Null check: entry might be null if no value is selected
-				String displayValue = Objects.requireNonNull(entry).toString();
+
+				// Handle cases where no value has been selected yet. (backwards compatibility)
+				String displayValue;
+				if (entry == null || TextUtils.isEmpty(entry)) {
+					// Fallback text if no value is set.
+					displayValue = getString(R.string.prefs_not_set);
+				} else {
+					displayValue = entry.toString();
+				}
 				return displayValue + ".\n" + staticSummary;
 			});
 		}

--- a/app/src/main/res/values/strings-preferences.xml
+++ b/app/src/main/res/values/strings-preferences.xml
@@ -117,4 +117,6 @@
   <string name="prefs_compass_heading">Export compass heading</string>
   <string name="prefs_compass_heading_summary">Defines if and how the compass data should be exported to the GPX file</string>
   <string name="prefs_reset_default_value">Reset default value</string>
+  <string name="prefs_not_set">Not set</string>
+
 </resources>


### PR DESCRIPTION
## 📖 Description
In versions <2025.02, the pref value for the source of photos is not set. Due to improvements in preferences, when the app gets upgraded, the preferences screen disappears when rendering that pref because of the nonexistence of a selected value. 
