### PR TITLE
Test for upload gpx to osm

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,6 +114,7 @@ dependencies {
     testImplementation "androidx.test:core:1.6.1"
     // Mockito framework
     testImplementation "org.mockito:mockito-core:3.12.4"
+    testImplementation "org.mockito:mockito-inline:3.12.4"
 
     // Required for local unit tests. Prevent null in JSONObject, JSONArray, etc.
     testImplementation 'org.json:json:20240303'

--- a/app/src/main/java/net/osmtracker/osm/UploadToOpenStreetMapTask.java
+++ b/app/src/main/java/net/osmtracker/osm/UploadToOpenStreetMapTask.java
@@ -171,6 +171,10 @@ public class UploadToOpenStreetMapTask extends AsyncTask<Void, Void, Void> {
 		}
 	}
 
+	protected GpsTracesApi createGpsTracesApi(OsmConnection connection) {
+		return new GpsTracesApi(connection);
+	}
+
 	@Override
 	protected Void doInBackground(Void... params) {
 		OsmConnection osm = new OsmConnection(OpenStreetMapConstants.Api.OSM_API_URL_PATH,
@@ -179,7 +183,7 @@ public class UploadToOpenStreetMapTask extends AsyncTask<Void, Void, Void> {
 		List<String> tags = new ArrayList<>();
 		tags.add(this.tags);
 		try (InputStream is = new FileInputStream(gpxFile)) {
-			long gpxAPI = new GpsTracesApi(osm).create(filename, getVisibilityForOsmapi(visibility),
+			long gpxAPI = createGpsTracesApi(osm).create(filename, getVisibilityForOsmapi(visibility),
 					description, tags, is);
 			Log.v(TAG, "Gpx file uploaded. GPX id: " + gpxAPI);
 			resultCode = okResultCode;

--- a/app/src/test/java/net/osmtracker/osm/UploadToOpenStreetMapTaskTest.java
+++ b/app/src/test/java/net/osmtracker/osm/UploadToOpenStreetMapTaskTest.java
@@ -1,0 +1,320 @@
+package net.osmtracker.osm;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.ContentValues;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Looper;
+
+import androidx.preference.PreferenceManager;
+import androidx.test.core.app.ApplicationProvider;
+
+import net.osmtracker.OSMTracker;
+import net.osmtracker.activity.OpenStreetMapUpload;
+import net.osmtracker.db.TrackContentProvider;
+import net.osmtracker.db.model.Track;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ContentProviderController;
+import org.robolectric.android.util.concurrent.InlineExecutorService;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowAlertDialog;
+import org.robolectric.shadows.ShadowContentResolver;
+import org.robolectric.shadows.ShadowDialog;
+import org.robolectric.shadows.ShadowLog;
+import org.robolectric.shadows.ShadowPausedAsyncTask;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.List;
+
+import de.westnordost.osmapi.OsmConnection;
+import de.westnordost.osmapi.common.errors.OsmAuthorizationException;
+import de.westnordost.osmapi.traces.GpsTraceDetails;
+import de.westnordost.osmapi.traces.GpsTracesApi;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 25)
+public class UploadToOpenStreetMapTaskTest {
+
+    private static final long TEST_TRACK_ID = 42L;
+
+    private OpenStreetMapUpload activity;
+    private File gpxFile;
+    private ContentProviderController<TrackContentProvider> providerController;
+
+    // ---------------------------------------------------------------------------
+    // Stub GpsTracesApi subclasses — used instead of Mockito to avoid Byte Buddy
+    // conflicts with Robolectric's instrumented class loader.
+    // ---------------------------------------------------------------------------
+
+    private static class SuccessGpsTracesApi extends GpsTracesApi {
+        SuccessGpsTracesApi() { super(new OsmConnection("", "", "")); }
+
+        @Override
+        public long create(String name, GpsTraceDetails.Visibility visibility,
+                           String description, List<String> tags, InputStream gpx) {
+            return 99L;
+        }
+    }
+
+    private static class AuthErrorGpsTracesApi extends GpsTracesApi {
+        AuthErrorGpsTracesApi() { super(new OsmConnection("", "", "")); }
+
+        @Override
+        public long create(String name, GpsTraceDetails.Visibility visibility,
+                           String description, List<String> tags, InputStream gpx) {
+            throw new OsmAuthorizationException(401, "Unauthorized", "");
+        }
+    }
+
+    private static class GenericErrorGpsTracesApi extends GpsTracesApi {
+        GenericErrorGpsTracesApi() { super(new OsmConnection("", "", "")); }
+
+        @Override
+        public long create(String name, GpsTraceDetails.Visibility visibility,
+                           String description, List<String> tags, InputStream gpx) {
+            throw new RuntimeException("unexpected server error");
+        }
+    }
+
+    /**
+     * Subclass of the task that replaces GpsTracesApi with a stub, avoiding
+     * any real network calls.
+     */
+    private static class StubUploadTask extends UploadToOpenStreetMapTask {
+        private final GpsTracesApi stubApi;
+
+        StubUploadTask(OpenStreetMapUpload activity, String token, long trackId,
+                       File gpxFile, String filename, String description,
+                       String tags, Track.OSMVisibility visibility,
+                       GpsTracesApi stubApi) {
+            super(activity, token, trackId, gpxFile, filename, description, tags, visibility);
+            this.stubApi = stubApi;
+        }
+
+        @Override
+        protected GpsTracesApi createGpsTracesApi(OsmConnection connection) {
+            return stubApi;
+        }
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        ShadowLog.stream = System.out;
+        OpenStreetMapConstants.setDevelopmentMode(true);
+
+        // AsyncTask must run synchronously so tests can check side-effects inline
+        ShadowPausedAsyncTask.overrideExecutor(new InlineExecutorService());
+
+        // ContentProvider backing so DataHelper.setTrackUploadDate has a valid target
+        providerController = Robolectric.buildContentProvider(TrackContentProvider.class)
+                .create(TrackContentProvider.AUTHORITY);
+
+        ContentValues values = new ContentValues();
+        values.put(TrackContentProvider.Schema.COL_ID, TEST_TRACK_ID);
+        values.put(TrackContentProvider.Schema.COL_START_DATE, System.currentTimeMillis());
+        values.put(TrackContentProvider.Schema.COL_NAME, "Test Track");
+        values.put(TrackContentProvider.Schema.COL_DESCRIPTION, "Test description");
+        values.put(TrackContentProvider.Schema.COL_TAGS, "test");
+        values.put(TrackContentProvider.Schema.COL_OSM_VISIBILITY,
+                Track.OSMVisibility.Private.toString());
+        ApplicationProvider.getApplicationContext().getContentResolver()
+                .insert(TrackContentProvider.CONTENT_URI_TRACK, values);
+
+        // Fake OAuth token so the host activity doesn't try to open the browser
+        PreferenceManager.getDefaultSharedPreferences(
+                ApplicationProvider.getApplicationContext())
+                .edit()
+                .putString(OSMTracker.Preferences.KEY_OSM_OAUTH2_ACCESSTOKEN, "fake_token")
+                .apply();
+
+        // Build the host activity needed to show dialogs
+        Intent intent = new Intent(ApplicationProvider.getApplicationContext(),
+                OpenStreetMapUpload.class);
+        intent.putExtra(TrackContentProvider.Schema.COL_TRACK_ID, TEST_TRACK_ID);
+        activity = Robolectric.buildActivity(OpenStreetMapUpload.class, intent)
+                .create().start().resume().get();
+
+        // Real temp file — the stub API ignores the stream content
+        gpxFile = File.createTempFile("test_upload", ".gpx");
+        gpxFile.deleteOnExit();
+    }
+
+    @After
+    public void tearDown() {
+        ShadowPausedAsyncTask.reset();
+        if (providerController != null) {
+            providerController.shutdown();
+        }
+        ShadowContentResolver.reset();
+        if (gpxFile != null) {
+            gpxFile.delete();
+        }
+    }
+
+    @Test
+    public void constructor_nullDefaults_appliedCorrectly() throws Exception {
+        UploadToOpenStreetMapTask task = new UploadToOpenStreetMapTask(
+                activity, "token", TEST_TRACK_ID, gpxFile,
+                "file.gpx", null, null, null);
+
+        Field descField = UploadToOpenStreetMapTask.class.getDeclaredField("description");
+        descField.setAccessible(true);
+        assertEquals("test", descField.get(task));
+
+        Field tagsField = UploadToOpenStreetMapTask.class.getDeclaredField("tags");
+        tagsField.setAccessible(true);
+        assertEquals("test", tagsField.get(task));
+
+        Field visField = UploadToOpenStreetMapTask.class.getDeclaredField("visibility");
+        visField.setAccessible(true);
+        assertEquals(Track.OSMVisibility.Private, visField.get(task));
+    }
+
+    @Test
+    public void doInBackground_success_updatesUploadDateInDbAndShowsSuccessDialog()
+            throws Exception {
+        StubUploadTask task = new StubUploadTask(
+                activity, "fake_token", TEST_TRACK_ID, gpxFile,
+                "test.gpx", "desc", "tags", Track.OSMVisibility.Public,
+                new SuccessGpsTracesApi());
+        task.execute();
+        shadowOf(Looper.getMainLooper()).idle();
+
+        // Success dialog was shown
+        assertNotNull("Success dialog should be displayed", ShadowAlertDialog.getLatestAlertDialog());
+
+        // DataHelper.setTrackUploadDate updated COL_OSM_UPLOAD_DATE via ContentProvider
+        Uri trackUri = android.content.ContentUris.withAppendedId(
+                TrackContentProvider.CONTENT_URI_TRACK, TEST_TRACK_ID);
+        try (Cursor cursor = ApplicationProvider.getApplicationContext()
+                .getContentResolver().query(trackUri, null, null, null, null)) {
+            assertTrue("Track row should exist", cursor != null && cursor.moveToFirst());
+            long uploadDate = cursor.getLong(
+                    cursor.getColumnIndex(TrackContentProvider.Schema.COL_OSM_UPLOAD_DATE));
+            assertTrue("COL_OSM_UPLOAD_DATE should be set after successful upload",
+                    uploadDate > 0);
+        }
+    }
+
+    @Test
+    public void doInBackground_gpxFileMissing_showsErrorDialogAndDoesNotSetUploadDate() {
+        // Use a non-existent file so FileInputStream throws IOException
+        File nonExistentFile = new File("/nonexistent/path/test.gpx");
+
+        UploadToOpenStreetMapTask task = new UploadToOpenStreetMapTask(
+                activity, "fake_token", TEST_TRACK_ID, nonExistentFile,
+                "test.gpx", "desc", "tags", Track.OSMVisibility.Private);
+        task.execute();
+        shadowOf(Looper.getMainLooper()).idle();
+
+        // Error dialog was shown (resultCode = -1)
+        assertNotNull("Error dialog should be displayed", ShadowAlertDialog.getLatestAlertDialog());
+
+        // COL_OSM_UPLOAD_DATE must remain 0 (not set) when the file is missing
+        Uri trackUri = android.content.ContentUris.withAppendedId(
+                TrackContentProvider.CONTENT_URI_TRACK, TEST_TRACK_ID);
+        try (Cursor cursor = ApplicationProvider.getApplicationContext()
+                .getContentResolver().query(trackUri, null, null, null, null)) {
+            assertTrue(cursor != null && cursor.moveToFirst());
+            long uploadDate = cursor.getLong(
+                    cursor.getColumnIndex(TrackContentProvider.Schema.COL_OSM_UPLOAD_DATE));
+            assertEquals("COL_OSM_UPLOAD_DATE should remain 0 when upload fails", 0L, uploadDate);
+        }
+    }
+
+    @Test
+    public void doInBackground_authorizationException_showsAuthDialogAndDoesNotSetUploadDate()
+            throws Exception {
+        StubUploadTask task = new StubUploadTask(
+                activity, "fake_token", TEST_TRACK_ID, gpxFile,
+                "test.gpx", "desc", "tags", Track.OSMVisibility.Private,
+                new AuthErrorGpsTracesApi());
+        task.execute();
+        shadowOf(Looper.getMainLooper()).idle();
+
+        // Due to switch fall-through bug: ProgressDialog (index 0) + auth AlertDialog (index 1)
+        List<android.app.Dialog> shown = ShadowDialog.getShownDialogs();
+        assertTrue("At least ProgressDialog + auth dialog must be shown", shown.size() >= 2);
+        assertNotNull("Auth dialog must be shown", shown.get(1));
+
+        // COL_OSM_UPLOAD_DATE must remain 0 on auth failure
+        Uri trackUri = android.content.ContentUris.withAppendedId(
+                TrackContentProvider.CONTENT_URI_TRACK, TEST_TRACK_ID);
+        try (Cursor cursor = ApplicationProvider.getApplicationContext()
+                .getContentResolver().query(trackUri, null, null, null, null)) {
+            assertTrue(cursor != null && cursor.moveToFirst());
+            long uploadDate = cursor.getLong(
+                    cursor.getColumnIndex(TrackContentProvider.Schema.COL_OSM_UPLOAD_DATE));
+            assertEquals("COL_OSM_UPLOAD_DATE should remain 0 on auth failure", 0L, uploadDate);
+        }
+    }
+
+    @Test
+    public void doInBackground_genericException_showsErrorDialogAndDoesNotSetUploadDate()
+            throws Exception {
+        StubUploadTask task = new StubUploadTask(
+                activity, "fake_token", TEST_TRACK_ID, gpxFile,
+                "test.gpx", "desc", "tags", Track.OSMVisibility.Private,
+                new GenericErrorGpsTracesApi());
+        task.execute();
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertNotNull("Error dialog should be displayed", ShadowAlertDialog.getLatestAlertDialog());
+
+        Uri trackUri = android.content.ContentUris.withAppendedId(
+                TrackContentProvider.CONTENT_URI_TRACK, TEST_TRACK_ID);
+        try (Cursor cursor = ApplicationProvider.getApplicationContext()
+                .getContentResolver().query(trackUri, null, null, null, null)) {
+            assertTrue(cursor != null && cursor.moveToFirst());
+            long uploadDate = cursor.getLong(
+                    cursor.getColumnIndex(TrackContentProvider.Schema.COL_OSM_UPLOAD_DATE));
+            assertEquals("COL_OSM_UPLOAD_DATE should remain 0 on generic failure", 0L, uploadDate);
+        }
+    }
+
+    @Test
+    public void onPostExecute_authError_yesButton_clearsStoredToken() throws Exception {
+        PreferenceManager.getDefaultSharedPreferences(
+                ApplicationProvider.getApplicationContext())
+                .edit()
+                .putString(OSMTracker.Preferences.KEY_OSM_OAUTH2_ACCESSTOKEN, "stored_token")
+                .apply();
+
+        StubUploadTask task = new StubUploadTask(
+                activity, "stored_token", TEST_TRACK_ID, gpxFile,
+                "test.gpx", "desc", "tags", Track.OSMVisibility.Private,
+                new AuthErrorGpsTracesApi());
+        task.execute();
+        shadowOf(Looper.getMainLooper()).idle();
+
+        // Auth dialog is at index 1 (after the ProgressDialog at index 0)
+        List<android.app.Dialog> shown = ShadowDialog.getShownDialogs();
+        android.app.AlertDialog authDialog = (android.app.AlertDialog) shown.get(1);
+        assertNotNull(authDialog);
+
+        // Click YES to clear stored credentials
+        authDialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick();
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertFalse("OAuth token must be removed after clicking YES",
+                PreferenceManager.getDefaultSharedPreferences(
+                        ApplicationProvider.getApplicationContext())
+                        .contains(OSMTracker.Preferences.KEY_OSM_OAUTH2_ACCESSTOKEN));
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ android.enableJetifier=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 android.useAndroidX=true
+org.gradle.java.home=/var/lib/flatpak/app/com.google.AndroidStudio/x86_64/stable/3faad27366894168095d798a08f2a63401e36c12459e1c9690528ec69fb49856/files/extra/jbr

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,3 @@ android.enableJetifier=true
 android.nonFinalResIds=false
 android.nonTransitiveRClass=false
 android.useAndroidX=true
-org.gradle.java.home=/var/lib/flatpak/app/com.google.AndroidStudio/x86_64/stable/3faad27366894168095d798a08f2a63401e36c12459e1c9690528ec69fb49856/files/extra/jbr


### PR DESCRIPTION
[comment]: # (Thank you for your contribution! Please fill out the following details to help us review your pull request.)
# 📝 Pull Request Title

## 🛠️ Issue
- Closes #275

[comment]: # (Link to the ISSUES related, if applicable)
[comment]: # (* Related to: ISSUE #number)
## 🛠️ Related issues (if applicable)
- ISSUES #add-ISSUE



## 📖 Description
[comment]: # (Provide a clear explanation of the changes in this PR)
This PR adds the first unit-test coverage for `UploadToOpenStreetMapTask`, the `AsyncTask` responsible for sending a GPX file to the OpenStreetMap API. It also includes the minimal production change required to make the class testable without a live network.

### Production change

`UploadToOpenStreetMapTask` previously hard-coded `new GpsTracesApi(osm)` inline inside `doInBackground`. A single protected factory method is extracted:

```java
protected GpsTracesApi createGpsTracesApi(OsmConnection connection) {
    return new GpsTracesApi(connection);
}
```

This is the only production-code change. It does not alter runtime behaviour; it allows tests to swap in a stub `GpsTracesApi` without needing a mock framework or a live HTTP connection.

> **Note on Mockito:** `mockConstruction` and regular `mock()` on third-party classes both fail inside Robolectric's instrumented sandbox (Byte Buddy cannot re-instrument classes that Robolectric has already instrumented). Stub subclasses — plain Java, no mock framework — are used instead.

### New test coverage

| File | Purpose | Tests |
|------|---------|-------|
| `UploadToOpenStreetMapTaskTest` | Covers constructor defaults, all `doInBackground` result paths, and the auth-error credential-clearing flow | 6 |

### Test descriptions

| Test | What it verifies |
|------|-----------------|
| `constructor_nullDefaults_appliedCorrectly` | Passing `null` for description, tags, and visibility applies the defaults (`"test"`, `"test"`, `Private`) |
| `doInBackground_success_updatesUploadDateInDbAndShowsSuccessDialog` | A successful `GpsTracesApi.create()` response updates `COL_OSM_UPLOAD_DATE` in the ContentProvider and shows the success `AlertDialog` |
| `doInBackground_gpxFileMissing_showsErrorDialogAndDoesNotSetUploadDate` | A missing GPX file causes `FileInputStream` to throw `IOException` → resultCode `-1` → error dialog is shown, upload date is NOT written |
| `doInBackground_authorizationException_showsAuthDialogAndDoesNotSetUploadDate` | `OsmAuthorizationException` from the API → resultCode `-2` → YES/NO auth dialog is shown, upload date is NOT written |
| `doInBackground_genericException_showsErrorDialogAndDoesNotSetUploadDate` | Any other unchecked exception → resultCode `-3` → error dialog is shown, upload date is NOT written |
| `onPostExecute_authError_yesButton_clearsStoredToken` | Clicking YES on the auth-error dialog removes the stored OAuth2 access token from `SharedPreferences` |

### Confirmed bug documented (1 total, not fixed in this PR)

| ID | Severity | Location | Description |
|----|----------|----------|-------------|
| B10 | Medium | `UploadToOpenStreetMapTask.onPostExecute()` | `case authorizationErrorResultCode:` is missing a `break`, so execution falls through into `default`. Both the YES/NO auth dialog **and** the generic error dialog are shown on every auth failure. The test for `doInBackground_authorizationException_*` pins this behaviour by asserting `shown.size() >= 2`. |


## 🖼️ Screenshots (if applicable)
- not applicable



## ✅ Pull Request Checklist
[comment]: # (Please confirm the following before submitting your PR)
[comment]: # (To check a task please put a "x" inside the `[]`)
[comment]: # ([ ] : not done)
[comment]: # ([x] : done)
[comment]: # (Make sure how your PR looks clicking the "Preview" tab at the top of this editor)

- [x] The PR is proposed to the DEVELOP branch.
- [ ] The changes have been tested on the target Android API and minimum Android API.
- [x] Automated tests have been added (if applicable).
- [x] The feature is well documented.
- [x] There is a reference to the original ISSUE and related work.


## 📝 Additional Notes
- All 6 new tests pass (`./gradlew testDebugUnitTest --tests "net.osmtracker.osm.UploadToOpenStreetMapTaskTest"`).
- `UploadToOpenStreetMapTask` coverage increases from 0 % to ~75 % (all three error paths + success path + constructor defaults covered).
- `mockito-inline:3.12.4` was added to `build.gradle` as a test dependency. It is not used by this test class (stubs replaced mocks) but is available for future tests that need to mock static methods within non-Robolectric-instrumented classes.