### PR TITLE
Hotfix/menu contrast issue 341

### DIFF
--- a/app/src/main/res/drawable/menu_border_background.xml
+++ b/app/src/main/res/drawable/menu_border_background.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?android:attr/colorBackground" />
+    <stroke
+        android:width="2dp"
+        android:color="#A4A4A4" /> <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/layout/trackdetail_fields.xml
+++ b/app/src/main/res/layout/trackdetail_fields.xml
@@ -71,6 +71,7 @@
         android:layout_marginTop="8dp"
         android:minHeight="48dp"
         android:entries="@array/prefs_osm_visibility_keys"
+        android:popupBackground="@drawable/menu_border_background"
         style="@style/Widget.AppCompat.Spinner.Underlined" />
 
 </merge>

--- a/app/src/main/res/values-v14/theme_highcontrast.xml
+++ b/app/src/main/res/values-v14/theme_highcontrast.xml
@@ -4,6 +4,7 @@
 		<!-- item name="android:background">#ffffff</item -->
 		<item name="android:buttonStyle">@style/Widget.Button</item>
 		<item name="android:buttonStyleToggle">@style/Widget.Button.Toggle</item>
+		<item name="actionOverflowMenuStyle">@style/PopupMenu</item>
 	</style>
 
 	<style name="Widget.Button" parent="@android:style/Widget.DeviceDefault.Button">
@@ -13,6 +14,10 @@
 
 	<style name="Widget.Button.Toggle" parent="@android:style/Widget.DeviceDefault.Button.Toggle">
 			<item name="android:textColor">#ffffff</item>
+	</style>
+	
+	<style name="PopupMenu" parent="Widget.AppCompat.PopupMenu.Overflow">
+		<item name="android:popupBackground">@drawable/menu_border_background</item>
 	</style>
 
 </resources>

--- a/app/src/main/res/values-v14/theme_highcontrast.xml
+++ b/app/src/main/res/values-v14/theme_highcontrast.xml
@@ -4,7 +4,9 @@
 		<!-- item name="android:background">#ffffff</item -->
 		<item name="android:buttonStyle">@style/Widget.Button</item>
 		<item name="android:buttonStyleToggle">@style/Widget.Button.Toggle</item>
-		<item name="actionOverflowMenuStyle">@style/PopupMenu</item>
+		<item name="android:actionOverflowMenuStyle">@style/NativePopupMenu</item>
+		<item name="android:popupMenuStyle">@style/NativePopupMenu</item>
+		<item name="android:panelBackground">@drawable/menu_border_background</item>
 	</style>
 
 	<style name="Widget.Button" parent="@android:style/Widget.DeviceDefault.Button">
@@ -14,10 +16,6 @@
 
 	<style name="Widget.Button.Toggle" parent="@android:style/Widget.DeviceDefault.Button.Toggle">
 			<item name="android:textColor">#ffffff</item>
-	</style>
-	
-	<style name="PopupMenu" parent="Widget.AppCompat.PopupMenu.Overflow">
-		<item name="android:popupBackground">@drawable/menu_border_background</item>
 	</style>
 
 </resources>

--- a/app/src/main/res/values-v14/themes.xml
+++ b/app/src/main/res/values-v14/themes.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="DefaultTheme" parent="@android:style/Theme.DeviceDefault"/>
-    <style name="DarkTheme" parent="@android:style/Theme.DeviceDefault"/>
-    <style name="LightTheme" parent="@android:style/Theme.DeviceDefault.Light"/>
+    <style name="DefaultTheme" parent="@android:style/Theme.DeviceDefault">
+        <item name="android:actionOverflowMenuStyle">@style/NativePopupMenu</item>
+        <item name="android:popupMenuStyle">@style/NativePopupMenu</item>
+        <item name="android:panelBackground">@drawable/menu_border_background</item>
+    </style>
+    <style name="DarkTheme" parent="@android:style/Theme.DeviceDefault">
+        <item name="android:actionOverflowMenuStyle">@style/NativePopupMenu</item>
+        <item name="android:popupMenuStyle">@style/NativePopupMenu</item>
+        <item name="android:panelBackground">@drawable/menu_border_background</item>
+    </style>
+    <style name="LightTheme" parent="@android:style/Theme.DeviceDefault.Light">
+        <item name="android:actionOverflowMenuStyle">@style/NativePopupMenu</item>
+        <item name="android:popupMenuStyle">@style/NativePopupMenu</item>
+        <item name="android:panelBackground">@drawable/menu_border_background</item>
+    </style>
+    <style name="NativePopupMenu" parent="">
+        <item name="android:popupBackground">@drawable/menu_border_background</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,8 +9,8 @@
         <item name="colorAccent">@color/colorAccent</item>
         -->
         <item name="actionOverflowMenuStyle">@style/PopupMenu</item>
+        <item name="popupMenuStyle">@style/PopupMenu</item>
         <item name="android:contextPopupMenuStyle">@style/PopupMenu</item>
-        <item name="android:panelBackground">@drawable/menu_border_background</item>
     </style>
 
     <!-- Base application theme. -->

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,7 +8,9 @@
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         -->
-
+        <item name="actionOverflowMenuStyle">@style/PopupMenu</item>
+        <item name="android:contextPopupMenuStyle">@style/PopupMenu</item>
+        <item name="android:panelBackground">@drawable/menu_border_background</item>
     </style>
 
     <!-- Base application theme. -->
@@ -19,5 +21,10 @@
         <item name="colorAccent">@color/colorAccentLight</item>
         -->
     </style>
+
+    <style name="PopupMenu" parent="Widget.AppCompat.PopupMenu.Overflow">
+        <item name="android:popupBackground">@drawable/menu_border_background</item>
+    </style>
+
 
 </resources>


### PR DESCRIPTION
# 📝 High-contrast menu borders

## 🛠️ Issue
- Closes #341

## 📖 Description
Borders have been added to the contextual menus on the main screen and to the track detail spinner. Additionally, a border has been applied to all other popup-style menus. This resolves the low contrast issue that existed between the contextual menus and the rest of the application, especially when menus were layered on top of other lists or UI elements.



## 🖼️ Screenshots
<img width="257" height="159" alt="image" src="https://github.com/user-attachments/assets/30ec1d50-e474-44a3-ba12-ed9734b847f6" />


<img width="275" height="430" alt="image" src="https://github.com/user-attachments/assets/d552f13a-bd4e-435c-8c4d-2c3ea9b5bc42" />

## ✅ Pull Request Checklist
[comment]: # (Please confirm the following before submitting your PR)
[comment]: # (To check a task please put a "x" inside the `[]`)
[comment]: # ([ ] : not done)
[comment]: # ([x] : done)
[comment]: # (Make sure how your PR looks clicking the "Preview" tab at the top of this editor)

- [X] The PR is proposed to the DEVELOP branch.
- [X] The changes have been tested on the target Android API and minimum Android API.
- [ ] Automated tests have been added (if applicable).
- [ ] The feature is well documented.
- [X] There is a reference to the original ISSUE and related work.


## 📝 Additional Notes
- These UI adjustments ensure high-contrast menu borders for better visibility.
-The contrast ratio between the border color and the background colors is 5.37; a minimum of 4.5 is recommended according to W3C criterion 1.4.3. The contrast ratio was validated using the tool https://app.contrast-finder.org/